### PR TITLE
Remove setAttribute calls from constructors to comply with Custom Elements spec

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,8 +55,12 @@ if (!window.customElements.get('md-header')) {
 class MarkdownBoldButtonElement extends MarkdownButtonElement {
   constructor() {
     super()
-    this.setAttribute('hotkey', 'b')
     styles.set(this, {prefix: '**', suffix: '**', trimFirst: true})
+  }
+
+  connectedCallback() {
+    super.connectedCallback()
+    this.setAttribute('hotkey', 'b')
   }
 }
 
@@ -68,8 +72,12 @@ if (!window.customElements.get('md-bold')) {
 class MarkdownItalicButtonElement extends MarkdownButtonElement {
   constructor() {
     super()
-    this.setAttribute('hotkey', 'i')
     styles.set(this, {prefix: '_', suffix: '_', trimFirst: true})
+  }
+
+  connectedCallback() {
+    super.connectedCallback()
+    this.setAttribute('hotkey', 'i')
   }
 }
 
@@ -105,8 +113,12 @@ if (!window.customElements.get('md-code')) {
 class MarkdownLinkButtonElement extends MarkdownButtonElement {
   constructor() {
     super()
-    this.setAttribute('hotkey', 'k')
     styles.set(this, {prefix: '[', suffix: '](url)', replaceNext: 'url', scanFor: 'https?://'})
+  }
+
+  connectedCallback() {
+    super.connectedCallback()
+    this.setAttribute('hotkey', 'k')
   }
 }
 
@@ -142,8 +154,12 @@ if (!window.customElements.get('md-ordered-list')) {
 class MarkdownTaskListButtonElement extends MarkdownButtonElement {
   constructor() {
     super()
-    this.setAttribute('hotkey', 'L')
     styles.set(this, {prefix: '- [ ] ', multiline: true, surroundWithNewlines: true})
+  }
+
+  connectedCallback() {
+    super.connectedCallback()
+    this.setAttribute('hotkey', 'L')
   }
 }
 


### PR DESCRIPTION
I've been getting this error when using these elements in Safari:

> NotSupportedError: A newly constructed custom element must not have attributes

The error only occurs for the bold, italic, link, and task-list elements. It turns out that these elements have a `this.setAttribute` call in their constructors which was causing this error.

According to the "[Requirements for custom element constructors](
https://www.w3.org/TR/custom-elements/#custom-element-conformance)" section of the spec:

> The element must not gain any attributes or children, as this violates the expectations of consumers who use the createElement or createElementNS methods.

> In general, work should be deferred to connectedCallback as much as possible—especially work involving fetching resources or rendering. However, note that connectedCallback can be called more than once, so any initialization work that is truly one-time will need a guard to prevent it from running twice.

This PR moves the `this.setAttribute` calls from the constructors into `connectedCallback`.