### PR TITLE
Fix expandSelectedText breaking sentences for block changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -256,9 +256,10 @@ function wordSelectionStart(text: string, i: number): number {
   return index
 }
 
-function wordSelectionEnd(text: string, i: number): number {
+function wordSelectionEnd(text: string, i: number, multiline: boolean): number {
   let index = i
-  while (text[index] && !text[index].match(/\s/)) {
+  const breakPoint = multiline ? /\n/ : /\s/
+  while (text[index] && !text[index].match(breakPoint)) {
     index++
   }
   return index
@@ -322,10 +323,15 @@ function styleSelectedText(textarea: HTMLTextAreaElement, styleArgs: StyleArgs) 
   insertText(textarea, result)
 }
 
-function expandSelectedText(textarea: HTMLTextAreaElement, prefixToUse: string, suffixToUse: string): string {
+function expandSelectedText(
+  textarea: HTMLTextAreaElement,
+  prefixToUse: string,
+  suffixToUse: string,
+  multiline: boolean = false
+): string {
   if (textarea.selectionStart === textarea.selectionEnd) {
     textarea.selectionStart = wordSelectionStart(textarea.value, textarea.selectionStart)
-    textarea.selectionEnd = wordSelectionEnd(textarea.value, textarea.selectionEnd)
+    textarea.selectionEnd = wordSelectionEnd(textarea.value, textarea.selectionEnd, multiline)
   } else {
     const expandedSelectionStart = textarea.selectionStart - prefixToUse.length
     const expandedSelectionEnd = textarea.selectionEnd + suffixToUse.length
@@ -399,7 +405,7 @@ function blockStyle(textarea: HTMLTextAreaElement, arg: StyleArgs): SelectionRan
       prefixToUse = ` ${prefixToUse}`
     }
   }
-  selectedText = expandSelectedText(textarea, prefixToUse, suffixToUse)
+  selectedText = expandSelectedText(textarea, prefixToUse, suffixToUse, arg.multiline)
   let selectionStart = textarea.selectionStart
   let selectionEnd = textarea.selectionEnd
   const hasReplaceNext = replaceNext.length > 0 && suffixToUse.indexOf(replaceNext) > -1 && selectedText.length > 0

--- a/index.js
+++ b/index.js
@@ -258,8 +258,8 @@ function wordSelectionStart(text: string, i: number): number {
 
 function wordSelectionEnd(text: string, i: number, multiline: boolean): number {
   let index = i
-  const breakPoint = multiline ? /\n/ : /\s/
-  while (text[index] && !text[index].match(breakPoint)) {
+  const breakpoint = multiline ? /\n/ : /\s/
+  while (text[index] && !text[index].match(breakpoint)) {
     index++
   }
   return index

--- a/test/test.js
+++ b/test/test.js
@@ -389,6 +389,12 @@ describe('markdown-toolbbar-element', function() {
         assert.equal('|Two|', visualValue())
       })
 
+      it('creates ordered list without selection', function() {
+        setVisualValue('apple\n|pear\nbanana\n')
+        clickToolbar('md-ordered-list')
+        assert.equal('apple\n\n|1. |\n\npear\nbanana\n', visualValue())
+      })
+
       it('creates ordered list by selecting one line', function() {
         setVisualValue('apple\n|pear|\nbanana\n')
         clickToolbar('md-ordered-list')

--- a/test/test.js
+++ b/test/test.js
@@ -351,10 +351,16 @@ describe('markdown-toolbbar-element', function() {
     })
 
     describe('lists', function() {
-      it('turns line into list when you click the unordered list icon', function() {
+      it('turns line into list when you click the unordered list icon with selection', function() {
         setVisualValue('One\n|Two|\nThree\n')
         clickToolbar('md-unordered-list')
         assert.equal('One\n\n- |Two|\n\nThree\n', visualValue())
+      })
+
+      it('turns line into list when you click the unordered list icon without selection', function() {
+        setVisualValue('One\n|Two and two\nThree\n')
+        clickToolbar('md-unordered-list')
+        assert.equal('One\n\n- |Two and two\n\nThree\n', visualValue())
       })
 
       it('turns multiple lines into list when you click the unordered list icon', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -300,6 +300,12 @@ describe('markdown-toolbbar-element', function() {
         assert.equal('> |Butts|\n\nThe quick brown fox jumps over the lazy dog', visualValue())
       })
 
+      it('quotes full line of text when you click the quote icon', function() {
+        setVisualValue('|The quick brown fox jumps over the lazy dog')
+        clickToolbar('md-quote')
+        assert.equal('> |The quick brown fox jumps over the lazy dog', visualValue())
+      })
+
       it('prefixes newlines when quoting an existing line on an existing', function() {
         setVisualValue('The quick brown fox jumps over the lazy dog|Butts|')
         clickToolbar('md-quote')


### PR DESCRIPTION
Fixes #1.

With section at the beginning of text–

## Before

### Unordered list

```
- Fix 

expandSelectedText breaking sentences for block changes
```

### Blockquote

```
> Fix 

expandSelectedText breaking sentences for block changes
```

## After

### Unordered list

```
- Fix expandSelectedText breaking sentences for block changes
```

### Blockquote

```
> Fix expandSelectedText breaking sentences for block changes
```

## Ordered list

Ordered list has a special case behavior, which remains unchanged.

```
1.

Fix expandSelectedText breaking sentences for block changes
```

## Others

Inline markdown changes (bold/italic/link) remain on changed (ie will only expand to the first word). For example:

```
**Fix** expandSelectedText breaking sentences for block changes
```
