### PR TITLE
OrderedList fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -484,13 +484,27 @@ function orderedList(textarea: HTMLTextAreaElement): SelectionRange {
   let selectionEnd
   let selectionStart
   let text = textarea.value.slice(textarea.selectionStart, textarea.selectionEnd)
+  let textToUnstyle = text
   let lines = text.split('\n')
-
-  const undoStyling = lines.every(line => orderedListRegex.test(line))
+  let startOfLine, endOfLine
+  if (noInitialSelection) {
+    const linesBefore = textarea.value.slice(0, textarea.selectionStart).split(/\n/)
+    startOfLine = textarea.selectionStart - linesBefore[linesBefore.length - 1].length
+    endOfLine = wordSelectionEnd(textarea.value, textarea.selectionStart, true)
+    textToUnstyle = textarea.value.slice(startOfLine, endOfLine)
+  }
+  const linesToUnstyle = textToUnstyle.split('\n')
+  const undoStyling = linesToUnstyle.every(line => orderedListRegex.test(line))
 
   if (undoStyling) {
-    lines = lines.map(line => line.replace(orderedListRegex, ''))
+    lines = linesToUnstyle.map(line => line.replace(orderedListRegex, ''))
     text = lines.join('\n')
+    if (noInitialSelection && startOfLine && endOfLine) {
+      const lengthDiff = linesToUnstyle[0].length - lines[0].length
+      selectionStart = selectionEnd = textarea.selectionStart - lengthDiff
+      textarea.selectionStart = startOfLine
+      textarea.selectionEnd = endOfLine
+    }
   } else {
     lines = (function() {
       let i

--- a/index.js
+++ b/index.js
@@ -480,6 +480,7 @@ function multilineStyle(textarea: HTMLTextAreaElement, arg: StyleArgs) {
 
 function orderedList(textarea: HTMLTextAreaElement): SelectionRange {
   const orderedListRegex = /^\d+\.\s+/
+  const noInitialSelection = textarea.selectionStart === textarea.selectionEnd
   let selectionEnd
   let selectionStart
   let text = textarea.value.slice(textarea.selectionStart, textarea.selectionEnd)
@@ -506,6 +507,7 @@ function orderedList(textarea: HTMLTextAreaElement): SelectionRange {
     const {newlinesToAppend, newlinesToPrepend} = newlinesToSurroundSelectedText(textarea)
     selectionStart = textarea.selectionStart + newlinesToAppend.length
     selectionEnd = selectionStart + text.length
+    if (noInitialSelection) selectionStart = selectionEnd
     text = newlinesToAppend + text + newlinesToPrepend
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -398,7 +398,7 @@ describe('markdown-toolbbar-element', function() {
       it('creates ordered list without selection', function() {
         setVisualValue('apple\n|pear\nbanana\n')
         clickToolbar('md-ordered-list')
-        assert.equal('apple\n\n|1. |\n\npear\nbanana\n', visualValue())
+        assert.equal('apple\n\n1. |\n\npear\nbanana\n', visualValue())
       })
 
       it('creates ordered list by selecting one line', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -401,6 +401,18 @@ describe('markdown-toolbbar-element', function() {
         assert.equal('apple\n\n1. |\n\npear\nbanana\n', visualValue())
       })
 
+      it('undo an ordered list without selection', function() {
+        setVisualValue('apple\n1. |pear\nbanana\n')
+        clickToolbar('md-ordered-list')
+        assert.equal('apple\n|pear\nbanana\n', visualValue())
+      })
+
+      it('undo an ordered list without selection and puts cursor at the right position', function() {
+        setVisualValue('apple\n1. pea|r\nbanana\n')
+        clickToolbar('md-ordered-list')
+        assert.equal('apple\npea|r\nbanana\n', visualValue())
+      })
+
       it('creates ordered list by selecting one line', function() {
         setVisualValue('apple\n|pear|\nbanana\n')
         clickToolbar('md-ordered-list')


### PR DESCRIPTION
Reference: https://github.com/github/github/issues/110601#issuecomment-485593356.

1. Set cursor to end of line after inserting OL so user can start typing. Given– 

```
text
|text
```

Clicking on <kbd>OL</kbd>:

| Before | After |
|--|--|
|![image](https://user-images.githubusercontent.com/1153134/56608853-b6299d80-65d9-11e9-8151-81b3894b416d.png)|![image](https://user-images.githubusercontent.com/1153134/56609017-20424280-65da-11e9-8ce3-6026c36ad270.png)|

I believe previously a selection is set so people can click the button again to undo the insertion, which brings us to the second change 👇 .

2. Support undoing OL without selection. Given–

```
text
1. t|ext
```

Clicking on <kbd>OL</kbd>:

| Before | After |
|--|--|
|![image](https://user-images.githubusercontent.com/1153134/56608917-de190100-65d9-11e9-8cc9-810b6da96b9b.png)|![image](https://user-images.githubusercontent.com/1153134/56608968-fe48c000-65d9-11e9-930f-060f2cafec9e.png)|