### PR TITLE
add attribute support for setting the heading level

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,11 +44,7 @@ class MarkdownHeaderButtonElement extends MarkdownButtonElement {
   constructor() {
     super()
 
-    if (!this.hasAttribute('level')) {
-      this.setAttribute('level', '3')
-    }
-
-    const level = parseInt(this.getAttribute('level'), 10)
+    const level = parseInt(this.dataset.level || 3, 10)
     const prefix = `${'#'.repeat(level)} `
     styles.set(this, {
       prefix

--- a/index.js
+++ b/index.js
@@ -43,9 +43,16 @@ class MarkdownButtonElement extends HTMLElement {
 class MarkdownHeaderButtonElement extends MarkdownButtonElement {
   constructor() {
     super()
+
+    if (!this.hasAttribute('level')) {
+      this.setAttribute('level', '3')
+    }
+
+    const level = parseInt(this.getAttribute('level'), 10)
+    const prefix = `${'#'.repeat(level)} `
     styles.set(this, {
-      prefix: '#'.repeat(this.getAttribute('level') || 3).' '
-    });
+      prefix
+    })
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ class MarkdownHeaderButtonElement extends MarkdownButtonElement {
   constructor() {
     super()
 
-    const level = parseInt(this.dataset.level || 3, 10)
+    const level = parseInt(this.getAttribute('level') || 3, 10)
     const prefix = `${'#'.repeat(level)} `
     styles.set(this, {
       prefix

--- a/index.js
+++ b/index.js
@@ -43,7 +43,9 @@ class MarkdownButtonElement extends HTMLElement {
 class MarkdownHeaderButtonElement extends MarkdownButtonElement {
   constructor() {
     super()
-    styles.set(this, {prefix: '### '})
+    styles.set(this, {
+      prefix: '#'.repeat(this.getAttribute('level') || 3).' '
+    });
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -70,6 +70,7 @@ describe('markdown-toolbbar-element', function() {
         <markdown-toolbar for="textarea_id">
           <md-bold>bold</md-bold>
           <md-header>header</md-header>
+          <md-header level="1">h1</md-header>
           <md-italic>italic</md-italic>
           <md-quote>quote</md-quote>
           <md-code>code</md-code>
@@ -487,6 +488,19 @@ describe('markdown-toolbbar-element', function() {
         setVisualValue("GitHub's |homepage|")
         clickToolbar('md-link')
         assert.equal("GitHub's [homepage](|url|)", visualValue())
+      })
+    })
+
+    describe('header', function() {
+      it('inserts header syntax with cursor in description', function() {
+        setVisualValue('|title|')
+        clickToolbar('md-header')
+        assert.equal('### |title|', visualValue())
+      })
+      it('inserts header 1 syntax with cursor in description', function() {
+        setVisualValue('|title|')
+        clickToolbar('md-header[level="1"]')
+        assert.equal('# |title|', visualValue())
       })
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -70,7 +70,7 @@ describe('markdown-toolbbar-element', function() {
         <markdown-toolbar for="textarea_id">
           <md-bold>bold</md-bold>
           <md-header>header</md-header>
-          <md-header level="1">h1</md-header>
+          <md-header data-level="1">h1</md-header>
           <md-italic>italic</md-italic>
           <md-quote>quote</md-quote>
           <md-code>code</md-code>
@@ -499,7 +499,7 @@ describe('markdown-toolbbar-element', function() {
       })
       it('inserts header 1 syntax with cursor in description', function() {
         setVisualValue('|title|')
-        clickToolbar('md-header[level="1"]')
+        clickToolbar('md-header[data-level="1"]')
         assert.equal('# |title|', visualValue())
       })
     })

--- a/test/test.js
+++ b/test/test.js
@@ -70,7 +70,7 @@ describe('markdown-toolbbar-element', function() {
         <markdown-toolbar for="textarea_id">
           <md-bold>bold</md-bold>
           <md-header>header</md-header>
-          <md-header data-level="1">h1</md-header>
+          <md-header level="1">h1</md-header>
           <md-italic>italic</md-italic>
           <md-quote>quote</md-quote>
           <md-code>code</md-code>
@@ -499,7 +499,7 @@ describe('markdown-toolbbar-element', function() {
       })
       it('inserts header 1 syntax with cursor in description', function() {
         setVisualValue('|title|')
-        clickToolbar('md-header[data-level="1"]')
+        clickToolbar('md-header[level="1"]')
         assert.equal('# |title|', visualValue())
       })
     })


### PR DESCRIPTION
Hi,

I'll tidy this up and add tests/docs but wanted to get thoughts on adding attribute support for setting the heading level instead of it always being h3 (###). Example usage:

`<md-header level="1">h1</md-header>`
`<md-header level="6">h6</md-header>`

Paul