### PR TITLE
Load bundles based on what environment the user is in

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -21,7 +21,14 @@
       </markdown-toolbar>
       <textarea rows="6" class="mt-3 d-block width-full" id="textarea"></textarea>
     </div>
-    <!-- script src="../dist/index.umd.js"></script -->
-    <script src="https://unpkg.com/@github/markdown-toolbar-element@latest/dist/index.umd.js"></script>
+    <script>
+      const script = document.createElement('script')
+      if (window.location.hostname.endsWith('github.io')) {
+        script.src = "https://unpkg.com/@github/markdown-toolbar-element@latest/dist/index.umd.js"
+      } else {
+        script.src = "../dist/index.umd.js"
+      }
+      document.body.appendChild(script)
+    </script>
   </body>
 </html>


### PR DESCRIPTION
I keep messing this up and accidentally pushing those changes to PRs. What do you think about taking the manual editing of comments out of the equation and just load the correct script for the correct environment?

When running locally, you'll get the locally build bundle and when on gh-pages we'll load the unpkg one.

Ref: https://github.com/github/custom-element-boilerplate/pull/13