### PR TITLE
No more then six levels of headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,10 @@ class MarkdownHeaderButtonElement extends MarkdownButtonElement {
     super()
 
     const level = parseInt(this.getAttribute('level') || 3, 10)
+    if (level > 6) {
+      return
+    }
+
     const prefix = `${'#'.repeat(level)} `
     styles.set(this, {
       prefix

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ class MarkdownHeaderButtonElement extends MarkdownButtonElement {
     super()
 
     const level = parseInt(this.getAttribute('level') || 3, 10)
-    if (level > 6) {
+    if (level < 1 || level > 6) {
       return
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -71,6 +71,7 @@ describe('markdown-toolbar-element', function() {
           <md-bold>bold</md-bold>
           <md-header>header</md-header>
           <md-header level="1">h1</md-header>
+          <md-header level="10">h1</md-header>
           <md-italic>italic</md-italic>
           <md-quote>quote</md-quote>
           <md-code>code</md-code>
@@ -497,10 +498,17 @@ describe('markdown-toolbar-element', function() {
         clickToolbar('md-header')
         assert.equal('### |title|', visualValue())
       })
+
       it('inserts header 1 syntax with cursor in description', function() {
         setVisualValue('|title|')
         clickToolbar('md-header[level="1"]')
         assert.equal('# |title|', visualValue())
+      })
+
+      it('does not insert header for invalid level', function() {
+        setVisualValue('|title|')
+        clickToolbar('md-header[level="10"]')
+        assert.equal('|title|', visualValue())
       })
     })
   })


### PR DESCRIPTION
If a user tries to set heading to a level above 6, we just don't do anything.

cc/ @muan @mintbridge 

Fixes https://github.com/github/markdown-toolbar-element/issues/23