### PR TITLE
Feat add focus management for toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,12 @@ import '@github/markdown-toolbar-element'
   <md-task-list>task-list</md-task-list>
   <md-mention>mention</md-mention>
   <md-ref>ref</md-ref>
+  <button data-md-button>Custom button</button>
 </markdown-toolbar>
 <textarea id="textarea_id"></textarea>
 ```
+
+Focus management for buttons inside of the toolbar is automatically managed by the toolbar itself. The `md-*` buttons that ship with this package are automatically managed, but custom buttons needs a `data-md-button` attribute added to them, which enrolls them into focus management.
 
 ## Browser support
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import '@github/markdown-toolbar-element'
 <textarea id="textarea_id"></textarea>
 ```
 
-Focus management for buttons inside of the toolbar is automatically managed by the toolbar itself. The `md-*` buttons that ship with this package are automatically managed, but custom buttons needs a `data-md-button` attribute added to them, which enrolls them into focus management.
+`<markdown-toolbar>` comes with focus management as advised in [WAI-ARIA Authoring Practices 1.1: Toolbar Design Pattern](https://www.w3.org/TR/wai-aria-practices-1.1/examples/toolbar/toolbar.html). The `md-*` buttons that ship with this package are automatically managed. Add a `data-md-button` attribute to any custom toolbar items to enroll them into focus management.
 
 ## Browser support
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -6,6 +6,7 @@
   </head>
   <body>
     <div class="container py-4">
+      <p><a href="#">Add a Comment</a></p>
       <markdown-toolbar for="textarea">
         <md-bold class="btn btn-sm">bold</md-bold>
         <md-header class="btn btn-sm">header</md-header>

--- a/examples/index.html
+++ b/examples/index.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <div class="container py-4">
-      <p><a href="#">Add a Comment</a></p>
+      <p><button type="button">Add a Comment</button></p>
       <markdown-toolbar for="textarea">
         <md-bold class="btn btn-sm">bold</md-bold>
         <md-header class="btn btn-sm">header</md-header>

--- a/examples/index.html
+++ b/examples/index.html
@@ -24,11 +24,11 @@
       <textarea rows="6" class="mt-3 d-block width-full" id="textarea"></textarea>
     </div>
 
-    <details>
+    <details class="container py-4">
       <summary>Initially hidden toolbar!</summary>
       <div class="container py-4">
         <p><button type="button">Add a Comment</button></p>
-        <markdown-toolbar for="textarea">
+        <markdown-toolbar for="textarea2">
           <md-bold class="btn btn-sm">bold</md-bold>
           <md-header class="btn btn-sm">header</md-header>
           <md-italic class="btn btn-sm">italic</md-italic>
@@ -42,7 +42,7 @@
           <md-mention class="btn btn-sm">mention</md-mention>
           <md-ref class="btn btn-sm">ref</md-ref>
         </markdown-toolbar>
-        <textarea rows="6" class="mt-3 d-block width-full" id="textarea"></textarea>
+        <textarea rows="6" class="mt-3 d-block width-full" id="textarea2"></textarea>
       </div>
     </details>
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -23,6 +23,29 @@
       </markdown-toolbar>
       <textarea rows="6" class="mt-3 d-block width-full" id="textarea"></textarea>
     </div>
+
+    <details>
+      <summary>Initially hidden toolbar!</summary>
+      <div class="container py-4">
+        <p><button type="button">Add a Comment</button></p>
+        <markdown-toolbar for="textarea">
+          <md-bold class="btn btn-sm">bold</md-bold>
+          <md-header class="btn btn-sm">header</md-header>
+          <md-italic class="btn btn-sm">italic</md-italic>
+          <md-quote class="btn btn-sm">quote</md-quote>
+          <md-code class="btn btn-sm">code</md-code>
+          <md-link class="btn btn-sm">link</md-link>
+          <md-image class="btn btn-sm">image</md-image>
+          <md-unordered-list class="btn btn-sm">unordered-list</md-unordered-list>
+          <md-ordered-list class="btn btn-sm">ordered-list</md-ordered-list>
+          <md-task-list class="btn btn-sm">task-list</md-task-list>
+          <md-mention class="btn btn-sm">mention</md-mention>
+          <md-ref class="btn btn-sm">ref</md-ref>
+        </markdown-toolbar>
+        <textarea rows="6" class="mt-3 d-block width-full" id="textarea"></textarea>
+      </div>
+    </details>
+
     <script>
       const script = document.createElement('script')
       if (window.location.hostname.endsWith('github.io') || window.location.hostname.endsWith('github.com')) {

--- a/index.js
+++ b/index.js
@@ -292,7 +292,9 @@ function focusKeydown(event: KeyboardEvent) {
     buttons[i].setAttribute('tabindex', i === n ? '0' : '-1')
   }
 
-  buttons[n].focus()
+  if (buttons[n] instanceof HTMLElement) {
+    buttons[n].focus()
+  }
 }
 
 const shortcutListeners = new WeakMap()

--- a/index.js
+++ b/index.js
@@ -278,16 +278,17 @@ function focusKeydown(event: KeyboardEvent) {
   if (!(toolbar instanceof HTMLElement)) return
   const buttons = getButtons(toolbar)
   const index = buttons.indexOf(event.target)
+  const length = buttons.length
   if (index === -1) return
 
   let n = 0
   if (key === 'ArrowLeft') n = index - 1
   if (key === 'ArrowRight') n = index + 1
-  if (key === 'End') n = buttons.length - 1
-  if (n < 0) n = buttons.length - 1
-  if (n > buttons.length - 1) n = 0
+  if (key === 'End') n = length - 1
+  if (n < 0) n = length - 1
+  if (n > length - 1) n = 0
 
-  for (let i = 0; i < buttons.length; i += 1) {
+  for (let i = 0; i < length; i += 1) {
     buttons[i].setAttribute('tabindex', i === n ? '0' : '-1')
     if (i === n) {
       buttons[i].focus()

--- a/index.js
+++ b/index.js
@@ -1,6 +1,20 @@
 /* @flow strict */
 
-const buttonSelectors = ['[data-md-button]']
+const buttonSelectors = [
+  '[data-md-button]',
+  'md-header',
+  'md-bold',
+  'md-italic',
+  'md-quote',
+  'md-code',
+  'md-link',
+  'md-image',
+  'md-unordered-list',
+  'md-ordered-list',
+  'md-task-list',
+  'md-mention',
+  'md-ref'
+]
 function getButtons(toolbar: Element): Element[] {
   const els = []
   for (const button of toolbar.querySelectorAll(buttonSelectors.join(', '))) {
@@ -64,7 +78,6 @@ class MarkdownHeaderButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-header')) {
   window.MarkdownHeaderButtonElement = MarkdownHeaderButtonElement
   window.customElements.define('md-header', MarkdownHeaderButtonElement)
-  buttonSelectors.push('md-header')
 }
 
 class MarkdownBoldButtonElement extends MarkdownButtonElement {
@@ -82,7 +95,6 @@ class MarkdownBoldButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-bold')) {
   window.MarkdownBoldButtonElement = MarkdownBoldButtonElement
   window.customElements.define('md-bold', MarkdownBoldButtonElement)
-  buttonSelectors.push('md-bold')
 }
 
 class MarkdownItalicButtonElement extends MarkdownButtonElement {
@@ -100,7 +112,6 @@ class MarkdownItalicButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-italic')) {
   window.MarkdownItalicButtonElement = MarkdownItalicButtonElement
   window.customElements.define('md-italic', MarkdownItalicButtonElement)
-  buttonSelectors.push('md-italic')
 }
 
 class MarkdownQuoteButtonElement extends MarkdownButtonElement {
@@ -113,7 +124,6 @@ class MarkdownQuoteButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-quote')) {
   window.MarkdownQuoteButtonElement = MarkdownQuoteButtonElement
   window.customElements.define('md-quote', MarkdownQuoteButtonElement)
-  buttonSelectors.push('md-quote')
 }
 
 class MarkdownCodeButtonElement extends MarkdownButtonElement {
@@ -126,7 +136,6 @@ class MarkdownCodeButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-code')) {
   window.MarkdownCodeButtonElement = MarkdownCodeButtonElement
   window.customElements.define('md-code', MarkdownCodeButtonElement)
-  buttonSelectors.push('md-code')
 }
 
 class MarkdownLinkButtonElement extends MarkdownButtonElement {
@@ -144,7 +153,6 @@ class MarkdownLinkButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-link')) {
   window.MarkdownLinkButtonElement = MarkdownLinkButtonElement
   window.customElements.define('md-link', MarkdownLinkButtonElement)
-  buttonSelectors.push('md-link')
 }
 
 class MarkdownImageButtonElement extends MarkdownButtonElement {
@@ -157,7 +165,6 @@ class MarkdownImageButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-image')) {
   window.MarkdownImageButtonElement = MarkdownImageButtonElement
   window.customElements.define('md-image', MarkdownImageButtonElement)
-  buttonSelectors.push('md-image')
 }
 
 class MarkdownUnorderedListButtonElement extends MarkdownButtonElement {
@@ -170,7 +177,6 @@ class MarkdownUnorderedListButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-unordered-list')) {
   window.MarkdownUnorderedListButtonElement = MarkdownUnorderedListButtonElement
   window.customElements.define('md-unordered-list', MarkdownUnorderedListButtonElement)
-  buttonSelectors.push('md-unordered-list')
 }
 
 class MarkdownOrderedListButtonElement extends MarkdownButtonElement {
@@ -183,7 +189,6 @@ class MarkdownOrderedListButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-ordered-list')) {
   window.MarkdownOrderedListButtonElement = MarkdownOrderedListButtonElement
   window.customElements.define('md-ordered-list', MarkdownOrderedListButtonElement)
-  buttonSelectors.push('md-ordered-list')
 }
 
 class MarkdownTaskListButtonElement extends MarkdownButtonElement {
@@ -201,7 +206,6 @@ class MarkdownTaskListButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-task-list')) {
   window.MarkdownTaskListButtonElement = MarkdownTaskListButtonElement
   window.customElements.define('md-task-list', MarkdownTaskListButtonElement)
-  buttonSelectors.push('md-task-list')
 }
 
 class MarkdownMentionButtonElement extends MarkdownButtonElement {
@@ -214,7 +218,6 @@ class MarkdownMentionButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-mention')) {
   window.MarkdownMentionButtonElement = MarkdownMentionButtonElement
   window.customElements.define('md-mention', MarkdownMentionButtonElement)
-  buttonSelectors.push('md-mention')
 }
 
 class MarkdownRefButtonElement extends MarkdownButtonElement {
@@ -227,7 +230,6 @@ class MarkdownRefButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-ref')) {
   window.MarkdownRefButtonElement = MarkdownRefButtonElement
   window.customElements.define('md-ref', MarkdownRefButtonElement)
-  buttonSelectors.push('md-ref')
 }
 
 const modifierKey = navigator.userAgent.match(/Macintosh/) ? 'Meta' : 'Control'

--- a/index.js
+++ b/index.js
@@ -252,7 +252,7 @@ class MarkdownToolbarElement extends HTMLElement {
       shortcutListeners.set(this, fn)
     }
     this.setAttribute('tabindex', '0')
-    this.addEventListener('focus', onToolbarFocus)
+    this.addEventListener('focus', onToolbarFocus, {once: true})
   }
 
   disconnectedCallback() {

--- a/index.js
+++ b/index.js
@@ -225,9 +225,7 @@ class MarkdownToolbarElement extends HTMLElement {
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'toolbar')
     }
-    const focusKeydownfn = focusKeydown.bind(null, this)
-    this.addEventListener('keydown', focusKeydownfn)
-    focusListeners.set(this, focusKeydownfn)
+    this.addEventListener('keydown', focusKeydown)
     const fn = shortcut.bind(null, this)
     if (this.field) {
       this.field.addEventListener('keydown', fn)
@@ -243,10 +241,7 @@ class MarkdownToolbarElement extends HTMLElement {
       this.field.removeEventListener('keydown', fn)
       shortcutListeners.delete(this)
     }
-    const focusKeydownfn = focusListeners.get(this)
-    if (focusKeydownfn) {
-      this.removeEventListener('keydown', focusKeydownfn)
-    }
+    this.removeEventListener('keydown', focusKeydown)
   }
 
   get field(): ?HTMLTextAreaElement {
@@ -257,15 +252,15 @@ class MarkdownToolbarElement extends HTMLElement {
   }
 }
 
-const focusListeners = new WeakMap()
-
-function focusKeydown(toolbar: MarkdownToolbarElement, event: KeyboardEvent) {
+function focusKeydown(event: KeyboardEvent) {
   const key = event.key
   if (key !== 'ArrowRight' && key !== 'ArrowLeft' && key !== 'Home' && key !== 'End') return
   const target = event.target
+  const toolbar = event.currentTarget
   if (!(target instanceof HTMLElement)) return
+  if (!(toolbar instanceof HTMLElement)) return
   if (!target.hasAttribute('data-md-button')) return
-  if (target.closest('markdown-toolbar') !== event.currentTarget) return
+  if (target.closest('markdown-toolbar') !== toolbar) return
 
   const buttons = []
   for (const button of toolbar.querySelectorAll('[data-md-button]')) {

--- a/index.js
+++ b/index.js
@@ -274,8 +274,8 @@ class MarkdownToolbarElement extends HTMLElement {
 
 function onToolbarFocus({target}: FocusEvent) {
   if (!(target instanceof Element)) return
-  let tabindex = '0'
   target.removeAttribute('tabindex')
+  let tabindex = '0'
   for (const button of getButtons(target)) {
     button.setAttribute('tabindex', tabindex)
     if (tabindex === '0') {

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const buttonSelectors = [
 function getButtons(toolbar: Element): Element[] {
   const els = []
   for (const button of toolbar.querySelectorAll(buttonSelectors.join(', '))) {
-    if (button.closest('markdown-toolbar') === toolbar) els.push(button)
+    if (button.closest('markdown-toolbar') === toolbar && !button.hidden) els.push(button)
   }
   return els
 }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,9 @@ const buttonSelectors = [
 function getButtons(toolbar: Element): Element[] {
   const els = []
   for (const button of toolbar.querySelectorAll(buttonSelectors.join(', '))) {
-    if (button.closest('markdown-toolbar') === toolbar && !button.hidden) els.push(button)
+    // Skip buttons that are hidden, either via `hidden` attribute or CSS:
+    if (button.hidden || (button.offsetWidth <= 0 && button.offsetHeight <= 0)) continue
+    if (button.closest('markdown-toolbar') === toolbar) els.push(button)
   }
   return els
 }

--- a/index.js
+++ b/index.js
@@ -274,15 +274,15 @@ class MarkdownToolbarElement extends HTMLElement {
 function focusKeydown(event: KeyboardEvent) {
   const key = event.key
   if (key !== 'ArrowRight' && key !== 'ArrowLeft' && key !== 'Home' && key !== 'End') return
-  const target = event.target
   const toolbar = event.currentTarget
   if (!(toolbar instanceof HTMLElement)) return
   const buttons = getButtons(toolbar)
-  if (buttons.indexOf(event.target) === -1) return
+  const index = buttons.indexOf(event.target)
+  if (index === -1) return
 
   let n = 0
-  if (key === 'ArrowLeft') n = buttons.indexOf(target) - 1
-  if (key === 'ArrowRight') n = buttons.indexOf(target) + 1
+  if (key === 'ArrowLeft') n = index - 1
+  if (key === 'ArrowRight') n = index + 1
   if (key === 'End') n = buttons.length - 1
   if (n < 0) n = buttons.length - 1
   if (n > buttons.length - 1) n = 0

--- a/index.js
+++ b/index.js
@@ -306,6 +306,9 @@ function focusKeydown(event: KeyboardEvent) {
     buttons[i].setAttribute('tabindex', i === n ? '0' : '-1')
   }
 
+  // Need to stop home/end scrolling:
+  event.preventDefault()
+
   buttons[n].focus()
 }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,14 @@
 /* @flow strict */
 
+const buttonSelectors = ['[data-md-button]']
+function getButtons(toolbar: Element) {
+  const els = []
+  for (const button of toolbar.querySelectorAll(buttonSelectors.join(', '))) {
+    if (button.closest('markdown-toolbar') === toolbar) els.push(button)
+  }
+  return els
+}
+
 function keydown(fn: KeyboardEventHandler): KeyboardEventHandler {
   return function(event: KeyboardEvent) {
     if (event.key === ' ' || event.key === 'Enter') {
@@ -31,7 +40,6 @@ class MarkdownButtonElement extends HTMLElement {
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'button')
     }
-    this.setAttribute('data-md-button', '')
   }
 
   click() {
@@ -60,6 +68,7 @@ class MarkdownHeaderButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-header')) {
   window.MarkdownHeaderButtonElement = MarkdownHeaderButtonElement
   window.customElements.define('md-header', MarkdownHeaderButtonElement)
+  buttonSelectors.push('md-header')
 }
 
 class MarkdownBoldButtonElement extends MarkdownButtonElement {
@@ -77,6 +86,7 @@ class MarkdownBoldButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-bold')) {
   window.MarkdownBoldButtonElement = MarkdownBoldButtonElement
   window.customElements.define('md-bold', MarkdownBoldButtonElement)
+  buttonSelectors.push('md-bold')
 }
 
 class MarkdownItalicButtonElement extends MarkdownButtonElement {
@@ -94,6 +104,7 @@ class MarkdownItalicButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-italic')) {
   window.MarkdownItalicButtonElement = MarkdownItalicButtonElement
   window.customElements.define('md-italic', MarkdownItalicButtonElement)
+  buttonSelectors.push('md-italic')
 }
 
 class MarkdownQuoteButtonElement extends MarkdownButtonElement {
@@ -106,6 +117,7 @@ class MarkdownQuoteButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-quote')) {
   window.MarkdownQuoteButtonElement = MarkdownQuoteButtonElement
   window.customElements.define('md-quote', MarkdownQuoteButtonElement)
+  buttonSelectors.push('md-quote')
 }
 
 class MarkdownCodeButtonElement extends MarkdownButtonElement {
@@ -118,6 +130,7 @@ class MarkdownCodeButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-code')) {
   window.MarkdownCodeButtonElement = MarkdownCodeButtonElement
   window.customElements.define('md-code', MarkdownCodeButtonElement)
+  buttonSelectors.push('md-code')
 }
 
 class MarkdownLinkButtonElement extends MarkdownButtonElement {
@@ -135,6 +148,7 @@ class MarkdownLinkButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-link')) {
   window.MarkdownLinkButtonElement = MarkdownLinkButtonElement
   window.customElements.define('md-link', MarkdownLinkButtonElement)
+  buttonSelectors.push('md-link')
 }
 
 class MarkdownImageButtonElement extends MarkdownButtonElement {
@@ -147,6 +161,7 @@ class MarkdownImageButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-image')) {
   window.MarkdownImageButtonElement = MarkdownImageButtonElement
   window.customElements.define('md-image', MarkdownImageButtonElement)
+  buttonSelectors.push('md-image')
 }
 
 class MarkdownUnorderedListButtonElement extends MarkdownButtonElement {
@@ -159,6 +174,7 @@ class MarkdownUnorderedListButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-unordered-list')) {
   window.MarkdownUnorderedListButtonElement = MarkdownUnorderedListButtonElement
   window.customElements.define('md-unordered-list', MarkdownUnorderedListButtonElement)
+  buttonSelectors.push('md-unordered-list')
 }
 
 class MarkdownOrderedListButtonElement extends MarkdownButtonElement {
@@ -171,6 +187,7 @@ class MarkdownOrderedListButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-ordered-list')) {
   window.MarkdownOrderedListButtonElement = MarkdownOrderedListButtonElement
   window.customElements.define('md-ordered-list', MarkdownOrderedListButtonElement)
+  buttonSelectors.push('md-ordered-list')
 }
 
 class MarkdownTaskListButtonElement extends MarkdownButtonElement {
@@ -188,6 +205,7 @@ class MarkdownTaskListButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-task-list')) {
   window.MarkdownTaskListButtonElement = MarkdownTaskListButtonElement
   window.customElements.define('md-task-list', MarkdownTaskListButtonElement)
+  buttonSelectors.push('md-task-list')
 }
 
 class MarkdownMentionButtonElement extends MarkdownButtonElement {
@@ -200,6 +218,7 @@ class MarkdownMentionButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-mention')) {
   window.MarkdownMentionButtonElement = MarkdownMentionButtonElement
   window.customElements.define('md-mention', MarkdownMentionButtonElement)
+  buttonSelectors.push('md-mention')
 }
 
 class MarkdownRefButtonElement extends MarkdownButtonElement {
@@ -212,6 +231,7 @@ class MarkdownRefButtonElement extends MarkdownButtonElement {
 if (!window.customElements.get('md-ref')) {
   window.MarkdownRefButtonElement = MarkdownRefButtonElement
   window.customElements.define('md-ref', MarkdownRefButtonElement)
+  buttonSelectors.push('md-ref')
 }
 
 const modifierKey = navigator.userAgent.match(/Macintosh/) ? 'Meta' : 'Control'
@@ -231,7 +251,7 @@ class MarkdownToolbarElement extends HTMLElement {
       this.field.addEventListener('keydown', fn)
       shortcutListeners.set(this, fn)
     }
-    const firstTabIndex = document.querySelector('[data-md-button]')
+    const firstTabIndex = getButtons(this)[0]
     if (firstTabIndex) firstTabIndex.setAttribute('tabindex', '0')
   }
 
@@ -257,25 +277,23 @@ function focusKeydown(event: KeyboardEvent) {
   if (key !== 'ArrowRight' && key !== 'ArrowLeft' && key !== 'Home' && key !== 'End') return
   const target = event.target
   const toolbar = event.currentTarget
-  if (!(target instanceof HTMLElement)) return
   if (!(toolbar instanceof HTMLElement)) return
-  if (!target.hasAttribute('data-md-button')) return
-  if (target.closest('markdown-toolbar') !== toolbar) return
+  const buttons = getButtons(toolbar)
+  if (buttons.indexOf(event.target) === -1) return
 
-  const buttons = []
-  for (const button of toolbar.querySelectorAll('[data-md-button]')) {
-    button.setAttribute('tabindex', '-1')
-    buttons.push(button)
+  let n = 0
+  if (key === 'ArrowLeft') n = buttons.indexOf(target) - 1
+  if (key === 'ArrowRight') n = buttons.indexOf(target) + 1
+  if (key === 'End') n = buttons.length - 1
+  if (n < 0) n = buttons.length - 1
+  if (n > buttons.length - 1) n = 0
+
+  for (let i = 0; i < buttons.length; i += 1) {
+    buttons[i].setAttribute('tabindex', i === n ? '0' : '-1')
+    if (i === n) {
+      buttons[i].focus()
+    }
   }
-  let i = 0
-  if (key === 'ArrowLeft') i = buttons.indexOf(target) - 1
-  if (key === 'ArrowRight') i = buttons.indexOf(target) + 1
-  if (key === 'End') i = buttons.length - 1
-  if (i < 0) i = buttons.length - 1
-  if (i > buttons.length - 1) i = 0
-
-  buttons[i].setAttribute('tabindex', '0')
-  buttons[i].focus()
 }
 
 const shortcutListeners = new WeakMap()

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const buttonSelectors = [
   'md-mention',
   'md-ref'
 ]
-function getButtons(toolbar: Element): Element[] {
+function getButtons(toolbar: Element): HTMLElement[] {
   const els = []
   for (const button of toolbar.querySelectorAll(buttonSelectors.join(', '))) {
     // Skip buttons that are hidden, either via `hidden` attribute or CSS:
@@ -251,11 +251,8 @@ class MarkdownToolbarElement extends HTMLElement {
       this.field.addEventListener('keydown', fn)
       shortcutListeners.set(this, fn)
     }
-    let tabindex = '0'
-    for (const button of getButtons(this)) {
-      button.setAttribute('tabindex', tabindex)
-      if (tabindex === '0') tabindex = '-1'
-    }
+    this.setAttribute('tabindex', '0')
+    this.addEventListener('focus', onToolbarFocus)
   }
 
   disconnectedCallback() {
@@ -272,6 +269,19 @@ class MarkdownToolbarElement extends HTMLElement {
     if (!id) return
     const field = document.getElementById(id)
     return field instanceof HTMLTextAreaElement ? field : null
+  }
+}
+
+function onToolbarFocus({target}: FocusEvent) {
+  if (!(target instanceof Element)) return
+  let tabindex = '0'
+  target.removeAttribute('tabindex')
+  for (const button of getButtons(target)) {
+    button.setAttribute('tabindex', tabindex)
+    if (tabindex === '0') {
+      button.focus()
+      tabindex = '-1'
+    }
   }
 }
 
@@ -296,9 +306,7 @@ function focusKeydown(event: KeyboardEvent) {
     buttons[i].setAttribute('tabindex', i === n ? '0' : '-1')
   }
 
-  if (buttons[n] instanceof HTMLElement) {
-    buttons[n].focus()
-  }
+  buttons[n].focus()
 }
 
 const shortcutListeners = new WeakMap()

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /* @flow strict */
 
 const buttonSelectors = ['[data-md-button]']
-function getButtons(toolbar: Element) {
+function getButtons(toolbar: Element): Element[] {
   const els = []
   for (const button of toolbar.querySelectorAll(buttonSelectors.join(', '))) {
     if (button.closest('markdown-toolbar') === toolbar) els.push(button)

--- a/index.js
+++ b/index.js
@@ -33,10 +33,6 @@ class MarkdownButtonElement extends HTMLElement {
   }
 
   connectedCallback() {
-    if (!this.hasAttribute('tabindex')) {
-      this.setAttribute('tabindex', '-1')
-    }
-
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'button')
     }
@@ -251,8 +247,11 @@ class MarkdownToolbarElement extends HTMLElement {
       this.field.addEventListener('keydown', fn)
       shortcutListeners.set(this, fn)
     }
-    const firstTabIndex = getButtons(this)[0]
-    if (firstTabIndex) firstTabIndex.setAttribute('tabindex', '0')
+    let tabindex = '0'
+    for (const button of getButtons(this)) {
+      button.setAttribute('tabindex', tabindex)
+      if (tabindex === '0') tabindex = '-1'
+    }
   }
 
   disconnectedCallback() {

--- a/index.js
+++ b/index.js
@@ -269,7 +269,6 @@ function focusKeydown(toolbar: MarkdownToolbarElement, event: KeyboardEvent) {
 
   const buttons = []
   for (const button of toolbar.querySelectorAll('[data-md-button]')) {
-    if (!(button instanceof MarkdownButtonElement)) continue
     button.setAttribute('tabindex', '-1')
     buttons.push(button)
   }

--- a/index.js
+++ b/index.js
@@ -9,13 +9,13 @@ function keydown(fn: KeyboardEventHandler): KeyboardEventHandler {
     }
     if (key === 'ArrowRight' || key === 'ArrowLeft' || key === 'Home' || key === 'End') {
       const target = event.currentTarget
-      if (!(target instanceof MarkdownButtonElement)) return
+      if (!(target instanceof HTMLElement)) return
+      if (!target.hasAttribute('data-md-button')) return
       const toolbar = target.closest('markdown-toolbar')
       if (!(toolbar instanceof MarkdownToolbarElement)) return
 
       const buttons = []
-      for (const button of toolbar.children) {
-        if (!(button instanceof MarkdownButtonElement)) continue
+      for (const button of toolbar.querySelectorAll('[data-md-button]')) {
         button.setAttribute('tabindex', '-1')
         buttons.push(button)
       }
@@ -54,6 +54,7 @@ class MarkdownButtonElement extends HTMLElement {
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'button')
     }
+    this.setAttribute('data-md-button', '')
   }
 
   click() {
@@ -252,7 +253,7 @@ class MarkdownToolbarElement extends HTMLElement {
       this.field.addEventListener('keydown', fn)
       shortcutListeners.set(this, fn)
     }
-    const firstTabIndex = document.querySelector('[role="button"][tabindex]')
+    const firstTabIndex = document.querySelector('[data-md-button]')
     if (firstTabIndex) firstTabIndex.setAttribute('tabindex', '0')
   }
 

--- a/index.js
+++ b/index.js
@@ -290,10 +290,9 @@ function focusKeydown(event: KeyboardEvent) {
 
   for (let i = 0; i < length; i += 1) {
     buttons[i].setAttribute('tabindex', i === n ? '0' : '-1')
-    if (i === n) {
-      buttons[i].focus()
-    }
   }
+
+  buttons[n].focus()
 }
 
 const shortcutListeners = new WeakMap()

--- a/index.js
+++ b/index.js
@@ -265,7 +265,7 @@ function focusKeydown(toolbar: MarkdownToolbarElement, event: KeyboardEvent) {
   const target = event.target
   if (!(target instanceof HTMLElement)) return
   if (!target.hasAttribute('data-md-button')) return
-  if (target.closest('markdown-toolbar') !== toolbar) return
+  if (target.closest('markdown-toolbar') !== event.currentTarget) return
 
   const buttons = []
   for (const button of toolbar.querySelectorAll('[data-md-button]')) {

--- a/test/test.js
+++ b/test/test.js
@@ -71,6 +71,7 @@ describe('markdown-toolbar-element', function() {
           <md-bold>bold</md-bold>
           <md-header>header</md-header>
           <md-header level="1">h1</md-header>
+          <md-header level="5" hidden>h1</md-header>
           <md-header level="10">h1</md-header>
           <div data-md-button>Other button</div>
           <md-italic>italic</md-italic>

--- a/test/test.js
+++ b/test/test.js
@@ -72,6 +72,7 @@ describe('markdown-toolbar-element', function() {
           <md-header>header</md-header>
           <md-header level="1">h1</md-header>
           <md-header level="10">h1</md-header>
+          <div data-md-button>Other button</div>
           <md-italic>italic</md-italic>
           <md-quote>quote</md-quote>
           <md-code>code</md-code>
@@ -112,15 +113,15 @@ describe('markdown-toolbar-element', function() {
       it('moves focus to next button when ArrowRight is pressed', function() {
         focusFirstButton()
         pushKeyOnFocussedButton('ArrowRight')
-        assert.equal(getElementsWithTabindex(-1).length, 13)
+        assert.equal(getElementsWithTabindex(-1).length, 14)
         assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-header')])
         assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
         pushKeyOnFocussedButton('ArrowRight')
-        assert.equal(getElementsWithTabindex(-1).length, 13)
+        assert.equal(getElementsWithTabindex(-1).length, 14)
         assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-header[level="1"]')])
         assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
         pushKeyOnFocussedButton('ArrowRight')
-        assert.equal(getElementsWithTabindex(-1).length, 13)
+        assert.equal(getElementsWithTabindex(-1).length, 14)
         assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-header[level="10"]')])
         assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
       })
@@ -128,11 +129,11 @@ describe('markdown-toolbar-element', function() {
       it('cycles focus round to last element from first when ArrowLeft is pressed', function() {
         focusFirstButton()
         pushKeyOnFocussedButton('ArrowLeft')
-        assert.equal(getElementsWithTabindex(-1).length, 13)
+        assert.equal(getElementsWithTabindex(-1).length, 14)
         assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-ref')])
         assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
         pushKeyOnFocussedButton('ArrowLeft')
-        assert.equal(getElementsWithTabindex(-1).length, 13)
+        assert.equal(getElementsWithTabindex(-1).length, 14)
         assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-mention')])
         assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
       })
@@ -140,20 +141,32 @@ describe('markdown-toolbar-element', function() {
       it('focussed first/last button when Home/End key is pressed', function() {
         focusFirstButton()
         pushKeyOnFocussedButton('End')
-        assert.equal(getElementsWithTabindex(-1).length, 13)
+        assert.equal(getElementsWithTabindex(-1).length, 14)
         assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-ref')])
         assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
         pushKeyOnFocussedButton('End')
-        assert.equal(getElementsWithTabindex(-1).length, 13)
+        assert.equal(getElementsWithTabindex(-1).length, 14)
         assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-ref')])
         assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
         pushKeyOnFocussedButton('Home')
-        assert.equal(getElementsWithTabindex(-1).length, 13)
+        assert.equal(getElementsWithTabindex(-1).length, 14)
         assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-bold')])
         assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
         pushKeyOnFocussedButton('Home')
-        assert.equal(getElementsWithTabindex(-1).length, 13)
+        assert.equal(getElementsWithTabindex(-1).length, 14)
         assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-bold')])
+        assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
+      })
+
+      it('counts `data-md-button` elements in the focussable set', function() {
+        focusFirstButton()
+        pushKeyOnFocussedButton('ArrowRight')
+        pushKeyOnFocussedButton('ArrowRight')
+        pushKeyOnFocussedButton('ArrowRight')
+        pushKeyOnFocussedButton('ArrowRight')
+        assert.equal(getElementsWithTabindex(-1).length, 14)
+        console.log(getElementsWithTabindex(0))
+        assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('div[data-md-button]')])
         assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
       })
     })

--- a/test/test.js
+++ b/test/test.js
@@ -113,6 +113,10 @@ describe('markdown-toolbar-element', function() {
         return [...document.querySelectorAll(`markdown-toolbar [tabindex="${index}"]`)]
       }
 
+      beforeEach(() => {
+        document.querySelector('markdown-toolbar').focus()
+      })
+
       it('moves focus to next button when ArrowRight is pressed', function() {
         focusFirstButton()
         pushKeyOnFocussedButton('ArrowRight')

--- a/test/test.js
+++ b/test/test.js
@@ -72,7 +72,7 @@ describe('markdown-toolbar-element', function() {
           <md-header>header</md-header>
           <md-header level="1">h1</md-header>
           <div hidden>
-            <md-header level="5">h1</md-header>
+            <md-header level="5">h5</md-header>
           </div>
           <md-header level="10">h1</md-header>
           <div data-md-button>Other button</div>

--- a/test/test.js
+++ b/test/test.js
@@ -165,7 +165,6 @@ describe('markdown-toolbar-element', function() {
         pushKeyOnFocussedButton('ArrowRight')
         pushKeyOnFocussedButton('ArrowRight')
         assert.equal(getElementsWithTabindex(-1).length, 14)
-        console.log(getElementsWithTabindex(0))
         assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('div[data-md-button]')])
         assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
       })

--- a/test/test.js
+++ b/test/test.js
@@ -92,6 +92,72 @@ describe('markdown-toolbar-element', function() {
       document.body.innerHTML = ''
     })
 
+    describe('focus management', function() {
+      function focusFirstButton() {
+        const button = document.querySelector('md-bold')
+        button.focus()
+      }
+
+      function pushKeyOnFocussedButton(key) {
+        const event = document.createEvent('Event')
+        event.initEvent('keydown', true, true)
+        event.key = key
+        document.activeElement.dispatchEvent(event)
+      }
+
+      function getElementsWithTabindex(index) {
+        return [...document.querySelectorAll(`markdown-toolbar [tabindex="${index}"]`)]
+      }
+
+      it('moves focus to next button when ArrowRight is pressed', function() {
+        focusFirstButton()
+        pushKeyOnFocussedButton('ArrowRight')
+        assert.equal(getElementsWithTabindex(-1).length, 13)
+        assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-header')])
+        assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
+        pushKeyOnFocussedButton('ArrowRight')
+        assert.equal(getElementsWithTabindex(-1).length, 13)
+        assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-header[level="1"]')])
+        assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
+        pushKeyOnFocussedButton('ArrowRight')
+        assert.equal(getElementsWithTabindex(-1).length, 13)
+        assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-header[level="10"]')])
+        assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
+      })
+
+      it('cycles focus round to last element from first when ArrowLeft is pressed', function() {
+        focusFirstButton()
+        pushKeyOnFocussedButton('ArrowLeft')
+        assert.equal(getElementsWithTabindex(-1).length, 13)
+        assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-ref')])
+        assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
+        pushKeyOnFocussedButton('ArrowLeft')
+        assert.equal(getElementsWithTabindex(-1).length, 13)
+        assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-mention')])
+        assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
+      })
+
+      it('focussed first/last button when Home/End key is pressed', function() {
+        focusFirstButton()
+        pushKeyOnFocussedButton('End')
+        assert.equal(getElementsWithTabindex(-1).length, 13)
+        assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-ref')])
+        assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
+        pushKeyOnFocussedButton('End')
+        assert.equal(getElementsWithTabindex(-1).length, 13)
+        assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-ref')])
+        assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
+        pushKeyOnFocussedButton('Home')
+        assert.equal(getElementsWithTabindex(-1).length, 13)
+        assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-bold')])
+        assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
+        pushKeyOnFocussedButton('Home')
+        assert.equal(getElementsWithTabindex(-1).length, 13)
+        assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-bold')])
+        assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
+      })
+    })
+
     describe('bold', function() {
       it('bold selected text when you click the bold icon', function() {
         setVisualValue('The |quick| brown fox jumps over the lazy dog')

--- a/test/test.js
+++ b/test/test.js
@@ -71,7 +71,9 @@ describe('markdown-toolbar-element', function() {
           <md-bold>bold</md-bold>
           <md-header>header</md-header>
           <md-header level="1">h1</md-header>
-          <md-header level="5" hidden>h1</md-header>
+          <div hidden>
+            <md-header level="5">h1</md-header>
+          </div>
           <md-header level="10">h1</md-header>
           <div data-md-button>Other button</div>
           <md-italic>italic</md-italic>


### PR DESCRIPTION
This follows best practices for toolbar focus management, following the guidelines available at https://www.w3.org/TR/wai-aria-practices-1.1/examples/toolbar/toolbar.html.

ArrowLeft/ArrowRight will switch tabindex/focus the next and previous buttons respectively, cycling round the whole toolbar if needed. Home and End keys were also implemented.

Refs https://github.com/github/github/issues/133916