### PR TITLE
Add getRootNode fallback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -298,7 +298,7 @@ class MarkdownToolbarElement extends HTMLElement {
   get field(): HTMLTextAreaElement | null {
     const id = this.getAttribute('for')
     if (!id) return null
-    const root = this.getRootNode()
+    const root = 'getRootNode' in this ? this.getRootNode() : document
     let field
     if (root instanceof Document || root instanceof ShadowRoot) {
       field = root.getElementById(id)


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode

We polyfill custom elements in Edge 18 but they don't have `getRootNode`.