### PR TITLE
Add hotkey to code block button

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -184,7 +184,7 @@ class MarkdownCodeButtonElement extends MarkdownButtonElement {
 
   connectedCallback() {
     super.connectedCallback()
-    this.setAttribute('hotkey', 'C')
+    this.setAttribute('hotkey', 'E')
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,6 +181,11 @@ class MarkdownCodeButtonElement extends MarkdownButtonElement {
     super()
     styles.set(this, {prefix: '`', suffix: '`', blockPrefix: '```', blockSuffix: '```'})
   }
+
+  connectedCallback() {
+    super.connectedCallback()
+    this.setAttribute('hotkey', 'C')
+  }
 }
 
 if (!window.customElements.get('md-code')) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -389,7 +389,8 @@ function findHotkey(toolbar: Element, key: string): HTMLElement | null {
 
 function shortcut(toolbar: Element, event: KeyboardEvent) {
   if ((event.metaKey && modifierKey === 'Meta') || (event.ctrlKey && modifierKey === 'Control')) {
-    const button = findHotkey(toolbar, event.key)
+    const key = event.shiftKey ? event.key.toUpperCase() : event.key
+    const button = findHotkey(toolbar, key)
     if (button) {
       button.click()
       event.preventDefault()

--- a/test/test.js
+++ b/test/test.js
@@ -209,7 +209,7 @@ describe('markdown-toolbar-element', function () {
       it('does not codeblock selected text when using the lowercased hotkey', function () {
         focus()
         setVisualValue('The |quick| brown fox jumps over the lazy dog')
-        pressHotkey('c') // lowercase `c` instead of uppercase `C`
+        pressHotkey('e') // lowercase `e` instead of uppercase `E`
         assert.equal('The |quick| brown fox jumps over the lazy dog', visualValue())
       })
     })
@@ -629,7 +629,7 @@ describe('markdown-toolbar-element', function () {
       it('surrounds a line with backticks via hotkey', function () {
         focus()
         setVisualValue("|puts 'Hello, world!'|")
-        pressHotkey('C')
+        pressHotkey('E')
         assert.equal("`|puts 'Hello, world!'|`", visualValue())
       })
 

--- a/test/test.js
+++ b/test/test.js
@@ -41,7 +41,12 @@ describe('markdown-toolbar-element', function () {
       event.initEvent('keydown', true, true)
       event.metaKey = osx
       event.ctrlKey = !osx
-      event.key = hotkey
+      event.shiftKey = hotkey === hotkey.toUpperCase()
+
+      // emulate existing osx browser bug
+      // https://bugs.webkit.org/show_bug.cgi?id=174782
+      event.key = osx ? hotkey.toLowerCase() : hotkey
+
       textarea.dispatchEvent(event)
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -614,6 +614,13 @@ describe('markdown-toolbar-element', function () {
         assert.equal("`|puts 'Hello, world!'|`", visualValue())
       })
 
+      it('surrounds a line with backticks via hotkey', function () {
+        focus()
+        setVisualValue("|puts 'Hello, world!'|")
+        pressHotkey('C')
+        assert.equal("`|puts 'Hello, world!'|`", visualValue())
+      })
+
       it('surrounds multiple lines with triple backticks if you click the code icon', function () {
         setVisualValue('|class Greeter\n  def hello_world\n    "Hello World!"\n  end\nend|')
         clickToolbar('md-code')

--- a/test/test.js
+++ b/test/test.js
@@ -193,6 +193,15 @@ describe('markdown-toolbar-element', function () {
       })
     })
 
+    describe('hotkey case-sensitivity', function () {
+      it('does not bold selected text when using the capitalized hotkey', function () {
+        focus()
+        setVisualValue('The |quick| brown fox jumps over the lazy dog')
+        pressHotkey('B') // capital `B` instead of lowercase `b`
+        assert.equal('The |quick| brown fox jumps over the lazy dog', visualValue())
+      })
+    })
+
     describe('bold', function () {
       it('bold selected text when you click the bold icon', function () {
         setVisualValue('The |quick| brown fox jumps over the lazy dog')

--- a/test/test.js
+++ b/test/test.js
@@ -199,10 +199,17 @@ describe('markdown-toolbar-element', function () {
     })
 
     describe('hotkey case-sensitivity', function () {
-      it('does not bold selected text when using the capitalized hotkey', function () {
+      it('does not bold selected text when using the uppercased hotkey', function () {
         focus()
         setVisualValue('The |quick| brown fox jumps over the lazy dog')
         pressHotkey('B') // capital `B` instead of lowercase `b`
+        assert.equal('The |quick| brown fox jumps over the lazy dog', visualValue())
+      })
+
+      it('does not codeblock selected text when using the lowercased hotkey', function () {
+        focus()
+        setVisualValue('The |quick| brown fox jumps over the lazy dog')
+        pressHotkey('c') // lowercase `c` instead of uppercase `C`
         assert.equal('The |quick| brown fox jumps over the lazy dog', visualValue())
       })
     })


### PR DESCRIPTION
## Description
This PR does the following:

* adds a hotkey of `C` for the `MarkdownCodeButtonElement`
* forces hotkeys to be case sensitive

## Issue
References: https://github.com/github/special-projects/issues/135

## Screenshots
Demonstrating the current behavior of hotkeys not being case sensitive:

![Screen Cast 2021-03-18 at 1 16 40 PM](https://user-images.githubusercontent.com/71267862/111668669-5bf8dd80-87ec-11eb-93c9-505a050dbd34.gif)

## Risk Assessment
**Low risk**