### PR TITLE
Change code block hotkey from E -> e

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -184,7 +184,7 @@ class MarkdownCodeButtonElement extends MarkdownButtonElement {
 
   connectedCallback() {
     super.connectedCallback()
-    this.setAttribute('hotkey', 'E')
+    this.setAttribute('hotkey', 'e')
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -205,13 +205,6 @@ describe('markdown-toolbar-element', function () {
         pressHotkey('B') // capital `B` instead of lowercase `b`
         assert.equal('The |quick| brown fox jumps over the lazy dog', visualValue())
       })
-
-      it('does not codeblock selected text when using the lowercased hotkey', function () {
-        focus()
-        setVisualValue('The |quick| brown fox jumps over the lazy dog')
-        pressHotkey('e') // lowercase `e` instead of uppercase `E`
-        assert.equal('The |quick| brown fox jumps over the lazy dog', visualValue())
-      })
     })
 
     describe('bold', function () {
@@ -629,7 +622,7 @@ describe('markdown-toolbar-element', function () {
       it('surrounds a line with backticks via hotkey', function () {
         focus()
         setVisualValue("|puts 'Hello, world!'|")
-        pressHotkey('E')
+        pressHotkey('e')
         assert.equal("`|puts 'Hello, world!'|`", visualValue())
       })
 


### PR DESCRIPTION
## Description
After some further discussion, design would like to change the hotkey to be lowercase to match the other shortcuts in use.

So, this PR:
* changes code hotkey from `cmd-shift-e` to `cmd-e` (in other words, uppercase `E` to lowercase `e`)

## Issue
References: https://github.com/github/special-projects/issues/135

## Screenshots
Keycastr was acting up on me here, but I was pressing `⌘+e`:

![Screen Cast 2021-03-22 at 12 30 44 PM](https://user-images.githubusercontent.com/71267862/112024635-c8d0e800-8b0a-11eb-875c-9e37ea201a1c.gif)

## Risk Assessment
**Low risk**