### PR TITLE
New keyboard shortcuts for quotes, bullets and numbered lists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -249,6 +249,11 @@ class MarkdownOrderedListButtonElement extends MarkdownButtonElement {
     super()
     styles.set(this, {prefix: '1. ', multiline: true, orderedList: true})
   }
+  connectedCallback() {
+    super.connectedCallback()
+    this.setAttribute('hotkey', '9')
+    this.setAttribute('hotkey-requires-shift', 'true')
+  }
 }
 
 if (!window.customElements.get('md-ordered-list')) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,6 +232,11 @@ class MarkdownUnorderedListButtonElement extends MarkdownButtonElement {
     super()
     styles.set(this, {prefix: '- ', multiline: true, surroundWithNewlines: true})
   }
+  connectedCallback() {
+    super.connectedCallback()
+    this.setAttribute('hotkey', '8')
+    this.setAttribute('hotkey-requires-shift', 'true')
+  }
 }
 
 if (!window.customElements.get('md-unordered-list')) {
@@ -387,10 +392,13 @@ function focusKeydown(event: KeyboardEvent) {
 }
 
 const shortcutListeners = new WeakMap()
+function elementHotkeyRequiresShift(element: Element): boolean {
+  return element.hasAttribute('hotkey-requires-shift') && element.getAttribute('hotkey-requires-shift') !== 'false'
+}
 
-function findHotkey(toolbar: Element, key: string): HTMLElement | null {
+function findHotkey(toolbar: Element, key: string, shiftPressed: boolean): HTMLElement | null {
   for (const el of toolbar.querySelectorAll<HTMLElement>('[hotkey]')) {
-    if (el.getAttribute('hotkey') === key) {
+    if (el.getAttribute('hotkey') === key && (!elementHotkeyRequiresShift(el) || shiftPressed)) {
       return el
     }
   }
@@ -400,7 +408,7 @@ function findHotkey(toolbar: Element, key: string): HTMLElement | null {
 function shortcut(toolbar: Element, event: KeyboardEvent) {
   if ((event.metaKey && modifierKey === 'Meta') || (event.ctrlKey && modifierKey === 'Control')) {
     const key = event.shiftKey ? event.key.toUpperCase() : event.key
-    const button = findHotkey(toolbar, key)
+    const button = findHotkey(toolbar, key, event.shiftKey)
     if (button) {
       button.click()
       event.preventDefault()

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,6 +169,11 @@ class MarkdownQuoteButtonElement extends MarkdownButtonElement {
     super()
     styles.set(this, {prefix: '> ', multiline: true, surroundWithNewlines: true})
   }
+
+  connectedCallback() {
+    super.connectedCallback()
+    this.setAttribute('hotkey', '.')
+  }
 }
 
 if (!window.customElements.get('md-quote')) {

--- a/test/test.js
+++ b/test/test.js
@@ -468,6 +468,13 @@ describe('markdown-toolbar-element', function () {
         assert.equal('> |', visualValue())
       })
 
+      it('inserts selected quoted sample via hotkey', function () {
+        focus()
+        setVisualValue('')
+        pressHotkey('.')
+        assert.equal('> |', visualValue())
+      })
+
       it('quotes the selected text when you click the quote icon', function () {
         setVisualValue('|Butts|\n\nThe quick brown fox jumps over the lazy dog')
         clickToolbar('md-quote')

--- a/test/test.js
+++ b/test/test.js
@@ -34,14 +34,14 @@ describe('markdown-toolbar-element', function () {
       textarea.dispatchEvent(event)
     }
 
-    function pressHotkey(hotkey) {
+    function pressHotkey(hotkey, explicitShiftKey = false) {
       const textarea = document.querySelector('textarea')
       const osx = navigator.userAgent.indexOf('Macintosh') !== -1
       const event = document.createEvent('Event')
       event.initEvent('keydown', true, true)
       event.metaKey = osx
       event.ctrlKey = !osx
-      event.shiftKey = hotkey === hotkey.toUpperCase()
+      event.shiftKey = (hotkey === hotkey.toUpperCase() && hotkey !== hotkey.toLowerCase()) || explicitShiftKey
 
       // emulate existing osx browser bug
       // https://bugs.webkit.org/show_bug.cgi?id=174782
@@ -554,6 +554,22 @@ describe('markdown-toolbar-element', function () {
         setVisualValue('One\n|Two\nThree|\n')
         clickToolbar('md-unordered-list')
         assert.equal('One\n\n|- Two\n- Three|\n', visualValue())
+      })
+
+      it('turns multiple lines into unordered list via hotkey, requiring shift', function () {
+        setVisualValue('One\n|Two\nThree|\n')
+        pressHotkey('8', false)
+        assert.equal('One\n|Two\nThree|\n', visualValue())
+        pressHotkey('8', true)
+        assert.equal('One\n\n|- Two\n- Three|\n', visualValue())
+      })
+
+      it('turns multiple lines into ordered list via hotkey, requiring shift', function () {
+        setVisualValue('One\n|Two\nThree|\n')
+        pressHotkey('9', false)
+        assert.equal('One\n|Two\nThree|\n', visualValue())
+        pressHotkey('9', true)
+        assert.equal('One\n\n|1. Two\n2. Three|\n', visualValue())
       })
 
       it('prefixes newlines when a list is created on the last line', function () {


### PR DESCRIPTION
This is the first part of https://github.com/github/special-projects/issues/524

The second part will be a `github/github` PR, which will update the vendored version of this module, and also add in tooltips.

This PR introduces a new `hotkey-requires-shift` attribute to allow hotkeys like `cmd+shift+8` (`*` is not be above `8` on all keyboards so that can't be used to mean the same as `shift+8`).

I'd appreciate any pointers about testing this. I did so locally by modifying the vendored `node_modules/@github/markdown-toolbar-element/dist/index.js` manually. Is that sufficient? Once I have a PR for updating the release number in `packages.json` in `github/github`, that could be tested on review lab.

I had a go at updating `packages.json` in `github/github` to point at this branch and running `bin/npm update @github/markdown-toolbar-element`, but it hung seemingly indefinitely at `info outdated updating [`.