### PR TITLE
Require pressing shift for the quote hotkey

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,7 @@ class MarkdownQuoteButtonElement extends MarkdownButtonElement {
   connectedCallback() {
     super.connectedCallback()
     this.setAttribute('hotkey', '.')
+    this.setAttribute('hotkey-requires-shift', 'true')
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -468,10 +468,12 @@ describe('markdown-toolbar-element', function () {
         assert.equal('> |', visualValue())
       })
 
-      it('inserts selected quoted sample via hotkey', function () {
+      it('inserts selected quoted sample via hotkey, requiring shift', function () {
         focus()
         setVisualValue('')
-        pressHotkey('.')
+        pressHotkey('.', false)
+        assert.equal('|', visualValue())
+        pressHotkey('.', true)
         assert.equal('> |', visualValue())
       })
 


### PR DESCRIPTION
This is to avoid conflicting with github's existing saved-reply shortcut