### PR TITLE
Make list behaviors more consistent, fix list stacking

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -703,8 +703,8 @@ function listStyle(textarea: HTMLTextAreaElement, style: StyleArgs): SelectionRa
     selectionStart = Math.max(selectionStart + prefix(0).length + newlinesToAppend.length, 0)
     selectionEnd = selectionStart
   } else {
-    selectionStart = Math.max(selectionStart + prefix(0).length + newlinesToAppend.length, 0)
-    selectionEnd = selectionEnd + newlinesToAppend.length + totalPrefixLength
+    selectionStart = Math.max(textarea.selectionStart + newlinesToAppend.length, 0)
+    selectionEnd = textarea.selectionEnd + newlinesToAppend.length + totalPrefixLength
   }
 
   const text = newlinesToAppend + lines.join('\n') + newlinesToPrepend

--- a/src/index.ts
+++ b/src/index.ts
@@ -433,7 +433,22 @@ function styleSelectedText(textarea: HTMLTextAreaElement, styleArgs: StyleArgs) 
   insertText(textarea, result)
 }
 
-export function selectionIndexForLine(lines: string[], line: number): SelectionRange | null {
+function expandSelectionToLine(textarea: HTMLTextAreaElement) {
+  const lines = textarea.value.split('\n')
+  let counter = 0
+  for (let index = 0; index < lines.length; index++) {
+    const lineLength = lines[index].length + 1
+    if (textarea.selectionStart >= counter && textarea.selectionStart <= counter + lineLength) {
+      textarea.selectionStart = counter
+    }
+    if (textarea.selectionEnd > counter && textarea.selectionEnd <= counter + lineLength) {
+      textarea.selectionEnd = counter + lineLength
+    }
+    counter += lineLength
+  }
+}
+
+function selectionIndexForLine(lines: string[], line: number): SelectionRange | null {
   let counter = 0
   for (let index = 0; index < lines.length; index++) {
     if (index === line) {
@@ -636,7 +651,9 @@ function listStyle(textarea: HTMLTextAreaElement, style: StyleArgs): SelectionRa
 
   const prefix = '- '
 
-  //let selectedText = expandSelectedText(textarea, prefix, '', style.multiline)
+  // Expand selection to full lines
+
+  expandSelectionToLine(textarea)
 
   // Style only the selected line
   if (noInitialSelection) {
@@ -648,10 +665,10 @@ function listStyle(textarea: HTMLTextAreaElement, style: StyleArgs): SelectionRa
 
     // Select whole line
     const range = selectionIndexForLine(lines, currentLine)
-    if (range) {
-      textarea.selectionStart = range.selectionStart ?? 0
-      textarea.selectionEnd = range.selectionEnd ?? 0
-    }
+    // if (range) {
+    //   textarea.selectionStart = range.selectionStart ?? 0
+    //   textarea.selectionEnd = range.selectionEnd ?? 0
+    // }
 
     // line with caret
     //lines[linesBefore.length - 1] = prefix + linesBefore[linesBefore.length - 1]
@@ -661,7 +678,7 @@ function listStyle(textarea: HTMLTextAreaElement, style: StyleArgs): SelectionRa
     // if (style.surroundWithNewlines) {
     const {newlinesToAppend, newlinesToPrepend} = newlinesToSurroundSelectedText(textarea)
     selectionStart = selectionStart + prefix.length + 1
-    selectionEnd = selectionStart
+    selectionEnd = selectionEnd + prefix.length + 1
     text = newlinesToAppend + text + newlinesToPrepend
 
     return {text, selectionStart, selectionEnd}

--- a/src/index.ts
+++ b/src/index.ts
@@ -692,7 +692,7 @@ function listStyle(textarea: HTMLTextAreaElement, style: StyleArgs): SelectionRa
       selectionEnd = selectionStart
     } else {
       selectionStart = Math.max(selectionStart - prefix(0).length, 0)
-      selectionEnd = selectionEnd + totalPrefixLength
+      selectionEnd = selectionEnd - totalPrefixLength
     }
     return {text: undoResult.text, selectionStart, selectionEnd}
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -688,7 +688,7 @@ function listStyle(textarea: HTMLTextAreaElement, style: StyleArgs): SelectionRa
       selectionEnd = selectionStart
     } else {
       selectionStart = textarea.selectionStart
-      selectionEnd = textarea.selectionEnd - prefix(0, style.unorderedList).length
+      selectionEnd = textarea.selectionEnd - totalPrefixLength
     }
     return {text: undoResult.text, selectionStart, selectionEnd}
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ type Style = {
   replaceNext?: string
   scanFor?: string
   orderedList?: boolean
+  unorderedList?: boolean
   prefixSpace?: boolean
 }
 
@@ -205,7 +206,7 @@ if (!window.customElements.get('md-image')) {
 class MarkdownUnorderedListButtonElement extends MarkdownButtonElement {
   constructor() {
     super()
-    styles.set(this, {prefix: '- ', multiline: true, surroundWithNewlines: true})
+    styles.set(this, {prefix: '- ', multiline: true, unorderedList: true})
   }
 }
 
@@ -421,8 +422,8 @@ function styleSelectedText(textarea: HTMLTextAreaElement, styleArgs: StyleArgs) 
   const text = textarea.value.slice(textarea.selectionStart, textarea.selectionEnd)
 
   let result
-  if (styleArgs.orderedList) {
-    result = orderedList(textarea)
+  if (styleArgs.orderedList || styleArgs.unorderedList) {
+    result = listStyle(textarea, styleArgs)
   } else if (styleArgs.multiline && isMultipleLines(text)) {
     result = multilineStyle(textarea, styleArgs)
   } else {
@@ -430,6 +431,17 @@ function styleSelectedText(textarea: HTMLTextAreaElement, styleArgs: StyleArgs) 
   }
 
   insertText(textarea, result)
+}
+
+export function selectionIndexForLine(lines: string[], line: number): SelectionRange | null {
+  let counter = 0
+  for (let index = 0; index < lines.length; index++) {
+    if (index === line) {
+      return {selectionStart: counter, selectionEnd: counter + lines[index].length, text: ''}
+    }
+    counter += lines[index].length + 1
+  }
+  return null
 }
 
 function expandSelectedText(
@@ -587,6 +599,79 @@ function multilineStyle(textarea: HTMLTextAreaElement, arg: StyleArgs) {
   return {text, selectionStart, selectionEnd}
 }
 
+function undoOrderedListStyle(textarea: HTMLTextAreaElement): string[] {
+  const text = textarea.value.slice(textarea.selectionStart, textarea.selectionEnd)
+  const lines = text.split('\n')
+  const orderedListRegex = /^\d+\.\s+/
+  const result = lines
+  const shouldUndoOrderedList = lines.every(line => orderedListRegex.test(line))
+  if (shouldUndoOrderedList) {
+    return lines.map(line => line.replace(orderedListRegex, ''))
+  }
+  return result
+}
+
+function undoUnorderedListStyle(textarea: HTMLTextAreaElement): string[] {
+  const text = textarea.value.slice(textarea.selectionStart, textarea.selectionEnd)
+  const lines = text.split('\n')
+  const unorderedListPrefix = '- '
+  const shouldUndoUnorderedList = lines.every(line => line.startsWith(unorderedListPrefix))
+  const result = lines
+  if (shouldUndoUnorderedList) {
+    return lines.map(line => line.slice(unorderedListPrefix.length, line.length))
+  }
+  return result
+}
+
+function listStyle(textarea: HTMLTextAreaElement, style: StyleArgs): SelectionRange {
+  const noInitialSelection = textarea.selectionStart === textarea.selectionEnd
+  let selectionStart = textarea.selectionStart
+  let selectionEnd = textarea.selectionEnd
+  let lines: string[] = []
+  let text = textarea.value.slice(textarea.selectionStart, textarea.selectionEnd)
+  let startOfLine, endOfLine
+
+  undoOrderedListStyle(textarea)
+  undoUnorderedListStyle(textarea)
+
+  const prefix = '- '
+
+  //let selectedText = expandSelectedText(textarea, prefix, '', style.multiline)
+
+  // Style only the selected line
+  if (noInitialSelection) {
+    const linesBefore = textarea.value.slice(0, textarea.selectionStart).split(/\n/)
+    lines = textarea.value.split('\n')
+
+    const currentLine = linesBefore.length - 1
+    const currentLineText = lines[currentLine]
+
+    // Select whole line
+    const range = selectionIndexForLine(lines, currentLine)
+    if (range) {
+      textarea.selectionStart = range.selectionStart ?? 0
+      textarea.selectionEnd = range.selectionEnd ?? 0
+    }
+
+    // line with caret
+    //lines[linesBefore.length - 1] = prefix + linesBefore[linesBefore.length - 1]
+
+    text = prefix + currentLineText
+
+    // if (style.surroundWithNewlines) {
+    const {newlinesToAppend, newlinesToPrepend} = newlinesToSurroundSelectedText(textarea)
+    selectionStart = selectionStart + prefix.length + 1
+    selectionEnd = selectionStart
+    text = newlinesToAppend + text + newlinesToPrepend
+
+    return {text, selectionStart, selectionEnd}
+  }
+
+  text = lines.join('\n')
+
+  return {text, selectionStart, selectionEnd}
+}
+
 function orderedList(textarea: HTMLTextAreaElement): SelectionRange {
   const orderedListRegex = /^\d+\.\s+/
   const noInitialSelection = textarea.selectionStart === textarea.selectionEnd
@@ -638,6 +723,7 @@ interface StyleArgs {
   scanFor: string
   surroundWithNewlines: boolean
   orderedList: boolean
+  unorderedList: boolean
   trimFirst: boolean
 }
 
@@ -668,6 +754,7 @@ function applyStyle(button: Element, stylesToApply: Style) {
     scanFor: '',
     surroundWithNewlines: false,
     orderedList: false,
+    unorderedList: false,
     trimFirst: false
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -691,7 +691,7 @@ function listStyle(textarea: HTMLTextAreaElement, style: StyleArgs): SelectionRa
       selectionStart = Math.max(selectionStart - prefix(0).length, 0)
       selectionEnd = selectionStart
     } else {
-      selectionStart = Math.max(selectionStart - prefix.length, 0)
+      selectionStart = Math.max(selectionStart - prefix(0).length, 0)
       selectionEnd = selectionEnd + totalPrefixLength
     }
     return {text: undoResult.text, selectionStart, selectionEnd}

--- a/src/index.ts
+++ b/src/index.ts
@@ -678,19 +678,6 @@ function listStyle(textarea: HTMLTextAreaElement, style: StyleArgs): SelectionRa
     selectedText = undoOrderedListStyle(undoResult.text).text
   }
 
-  if (undoResult.processed) {
-    //   // if (noInitialSelection) {
-    //   //   selectionStart = Math.max(selectionStart - prefix.length, 0)
-    //   //   selectionEnd = selectionStart
-    //   // } else {
-    //   //   selectionStart = Math.max(selectionStart - prefix.length, 0)
-    //   //   selectionEnd = selectionEnd + prefix.length // * lines.length
-    //   // }
-    return {text: undoResult.text, selectionStart, selectionEnd}
-  }
-
-  // selectedText = undoResult.text
-
   const lines = selectedText.split('\n').map((value, index) => {
     return `${prefix(index)}${value}`
   })
@@ -698,6 +685,17 @@ function listStyle(textarea: HTMLTextAreaElement, style: StyleArgs): SelectionRa
   const totalPrefixLength = lines.reduce((previousValue, currentValue, currentIndex) => {
     return previousValue + prefix(currentIndex).length
   }, 0)
+
+  if (undoResult.processed) {
+    if (noInitialSelection) {
+      selectionStart = Math.max(selectionStart - prefix(0).length, 0)
+      selectionEnd = selectionStart
+    } else {
+      selectionStart = Math.max(selectionStart - prefix.length, 0)
+      selectionEnd = selectionEnd + totalPrefixLength
+    }
+    return {text: undoResult.text, selectionStart, selectionEnd}
+  }
 
   const {newlinesToAppend, newlinesToPrepend} = newlinesToSurroundSelectedText(textarea)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -637,7 +637,7 @@ function undoUnorderedListStyle(text: string): UndoResult {
   }
 }
 
-const prefix = (index: number, unorderedList: boolean): string => {
+function makePrefix(index: number, unorderedList: boolean): string {
   if (unorderedList) {
     return '- '
   } else {
@@ -671,20 +671,20 @@ function listStyle(textarea: HTMLTextAreaElement, style: StyleArgs): SelectionRa
   }
 
   const lines = selectedText.split('\n').map((value, index) => {
-    return `${prefix(index, style.unorderedList)}${value}`
+    return `${makePrefix(index, style.unorderedList)}${value}`
   })
 
   const totalPrefixLength = lines.reduce((previousValue, currentValue, currentIndex) => {
-    return previousValue + prefix(currentIndex, style.unorderedList).length
+    return previousValue + makePrefix(currentIndex, style.unorderedList).length
   }, 0)
 
   const totalPrefixLengthOpositeList = lines.reduce((previousValue, currentValue, currentIndex) => {
-    return previousValue + prefix(currentIndex, !style.unorderedList).length
+    return previousValue + makePrefix(currentIndex, !style.unorderedList).length
   }, 0)
 
   if (undoResult.processed) {
     if (noInitialSelection) {
-      selectionStart = Math.max(selectionStart - prefix(0, style.unorderedList).length, 0)
+      selectionStart = Math.max(selectionStart - makePrefix(0, style.unorderedList).length, 0)
       selectionEnd = selectionStart
     } else {
       selectionStart = textarea.selectionStart
@@ -696,7 +696,7 @@ function listStyle(textarea: HTMLTextAreaElement, style: StyleArgs): SelectionRa
   const {newlinesToAppend, newlinesToPrepend} = newlinesToSurroundSelectedText(textarea)
 
   if (noInitialSelection) {
-    selectionStart = Math.max(selectionStart + prefix(0, style.unorderedList).length + newlinesToAppend.length, 0)
+    selectionStart = Math.max(selectionStart + makePrefix(0, style.unorderedList).length + newlinesToAppend.length, 0)
     selectionEnd = selectionStart
   } else {
     if (undoResultOpositeList.processed) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -656,7 +656,14 @@ function listStyle(textarea: HTMLTextAreaElement, style: StyleArgs): SelectionRa
   // Select whole line
   expandSelectionToLine(textarea)
 
-  const prefix = '- '
+  const prefix = (index: number): string => {
+    if (style.unorderedList) {
+      return '- '
+    } else if (style.orderedList) {
+      return `${index + 1}. `
+    }
+    return ''
+  }
 
   let selectedText = textarea.value.slice(textarea.selectionStart, textarea.selectionEnd)
 
@@ -664,30 +671,34 @@ function listStyle(textarea: HTMLTextAreaElement, style: StyleArgs): SelectionRa
   const undoUnorderedListResult = undoUnorderedListStyle(undoOrderedListResult.text)
 
   if (undoOrderedListResult.processed || undoUnorderedListResult.processed) {
-    if (noInitialSelection) {
-      selectionStart = Math.max(selectionStart - prefix.length, 0)
-      selectionEnd = selectionStart
-    } else {
-      selectionStart = Math.max(selectionStart - prefix.length, 0)
-      selectionEnd = selectionEnd + prefix.length // * lines.length
-    }
+    // if (noInitialSelection) {
+    //   selectionStart = Math.max(selectionStart - prefix.length, 0)
+    //   selectionEnd = selectionStart
+    // } else {
+    //   selectionStart = Math.max(selectionStart - prefix.length, 0)
+    //   selectionEnd = selectionEnd + prefix.length // * lines.length
+    // }
     return {text: undoUnorderedListResult.text, selectionStart, selectionEnd}
   }
 
   selectedText = undoUnorderedListResult.text
 
   const lines = selectedText.split('\n').map((value, index) => {
-    return `${prefix}${value}`
+    return `${prefix(index)}${value}`
   })
+
+  const totalPrefixLength = lines.reduce((previousValue, currentValue, currentIndex) => {
+    return previousValue + prefix(currentIndex).length
+  }, 0)
 
   const {newlinesToAppend, newlinesToPrepend} = newlinesToSurroundSelectedText(textarea)
 
   if (noInitialSelection) {
-    selectionStart = Math.max(selectionStart + prefix.length + newlinesToAppend.length, 0)
+    selectionStart = Math.max(selectionStart + prefix(0).length + newlinesToAppend.length, 0)
     selectionEnd = selectionStart
   } else {
-    selectionStart = Math.max(selectionStart + prefix.length + newlinesToAppend.length, 0)
-    selectionEnd = selectionEnd + newlinesToAppend.length + prefix.length * lines.length
+    selectionStart = Math.max(selectionStart + prefix(0).length + newlinesToAppend.length, 0)
+    selectionEnd = selectionEnd + newlinesToAppend.length + totalPrefixLength
   }
 
   const text = newlinesToAppend + lines.join('\n') + newlinesToPrepend

--- a/test/test.js
+++ b/test/test.js
@@ -526,7 +526,48 @@ describe('markdown-toolbar-element', function () {
         clickToolbar('md-unordered-list')
         assert.equal('- O|ne\n- Tw|o\n\nThree\n', visualValue())
       })
-      // TODO: Add undo test for all of this
+
+      it('undo list if cursor at end of line', function () {
+        setVisualValue('One\n\n- Two|\n\nThree\n')
+        clickToolbar('md-unordered-list')
+        assert.equal('One\nTwo|\nThree\n', visualValue())
+      })
+
+      it('undo list if cursor at end of document', function () {
+        setVisualValue('One\nTwo\n\n- Three|')
+        clickToolbar('md-unordered-list')
+        assert.equal('One\nTwo\nThree|', visualValue())
+      })
+
+      it('undo list if cursor at beginning of line', function () {
+        setVisualValue('One\n\n- |Two\n\nThree\n')
+        clickToolbar('md-unordered-list')
+        assert.equal('One\n|Two\nThree\n', visualValue())
+      })
+
+      it('undo list if cursor at middle of line', function () {
+        setVisualValue('One\n\n- T|wo\n\nThree\n')
+        clickToolbar('md-unordered-list')
+        assert.equal('One\nT|wo\nThree\n', visualValue())
+      })
+
+      it('undo list if partial line is selected', function () {
+        setVisualValue('One\n\n- T|w|o\n\nThree\n')
+        clickToolbar('md-unordered-list')
+        assert.equal('One\nT|w|o\nThree\n', visualValue())
+      })
+
+      it('undo two lines list if two lines are selected', function () {
+        setVisualValue('|- One\n- Two|\n\nThree\n')
+        clickToolbar('md-unordered-list')
+        assert.equal('|One\nTwo|\nThree\n', visualValue())
+      })
+
+      it('undo two lines list if 2 lines are partially selected', function () {
+        setVisualValue('- O|ne\n- Tw|o\n\nThree\n')
+        clickToolbar('md-unordered-list')
+        assert.equal('O|ne\nTw|o\nThree\n', visualValue())
+      })
     })
 
     describe('lists', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -571,6 +571,20 @@ describe('markdown-toolbar-element', function () {
     })
 
     describe('lists', function () {
+      it('does not stack list styles when selecting multiple lines', function () {
+        setVisualValue('One\n|Two\nThree|\n')
+        clickToolbar('md-ordered-list')
+        clickToolbar('md-unordered-list')
+        assert.equal('One\n\n|- Two\n- Three|\n', visualValue())
+      })
+
+      it('does not stack list styles when selecting one line', function () {
+        setVisualValue('One\n|Two|\nThree|\n')
+        clickToolbar('md-ordered-list')
+        clickToolbar('md-unordered-list')
+        assert.equal('One\n\n|- Two\n- Three|\n', visualValue())
+      })
+
       it('turns line into list when you click the unordered list icon with selection', function () {
         setVisualValue('One\n|Two|\nThree\n')
         clickToolbar('md-unordered-list')

--- a/test/test.js
+++ b/test/test.js
@@ -598,19 +598,19 @@ describe('markdown-toolbar-element', function () {
       it('undo list if partial line is selected', function () {
         setVisualValue('One\n\n- T|w|o\n\nThree\n')
         clickToolbar('md-unordered-list')
-        assert.equal('One\n\nT|w|o\n\nThree\n', visualValue())
+        assert.equal('One\n\n|Two|\n\nThree\n', visualValue())
       })
 
       it('undo two lines list if two lines are selected', function () {
         setVisualValue('|- One\n- Two|\n\nThree\n')
         clickToolbar('md-unordered-list')
-        assert.equal('|One\nTwo|\n\nThree\n', visualValue())
+        assert.equal('|One\nTwo\n\n|Three\n', visualValue())
       })
 
       it('undo two lines list if 2 lines are partially selected', function () {
         setVisualValue('- O|ne\n- Tw|o\n\nThree\n')
         clickToolbar('md-unordered-list')
-        assert.equal('O|ne\nTw|o\n\nThree\n', visualValue())
+        assert.equal('|One\nTwo\n\n|Three\n', visualValue())
       })
     })
 
@@ -619,14 +619,14 @@ describe('markdown-toolbar-element', function () {
         setVisualValue('One\n|Two\nThree|\n')
         clickToolbar('md-ordered-list')
         clickToolbar('md-unordered-list')
-        assert.equal('One\n\n|- Two\n- Three\n|', visualValue())
+        assert.equal('One\n\n|- Two\n- Three|\n', visualValue())
       })
 
       it('does not stack list styles when selecting one line', function () {
         setVisualValue('One\n|Two|\nThree\n')
         clickToolbar('md-ordered-list')
         clickToolbar('md-unordered-list')
-        assert.equal('One\n\n|- Two|\n\nThree', visualValue())
+        assert.equal('One\n\n|- Two|\n\nThree\n', visualValue())
       })
 
       it('turns line into list when you click the unordered list icon with selection', function () {
@@ -706,7 +706,7 @@ describe('markdown-toolbar-element', function () {
       it('undo an ordered list by selecting multiple styled lines', function () {
         setVisualValue('|1. One\n2. Two\n3. Three|\n')
         clickToolbar('md-ordered-list')
-        assert.equal('|One\nTwo\nThree|\n', visualValue())
+        assert.equal('|One\nTwo\nThree\n|', visualValue())
       })
     })
 

--- a/test/test.js
+++ b/test/test.js
@@ -526,19 +526,19 @@ describe('markdown-toolbar-element', function () {
         assertNormalizedList('One\n\n- |Two|\n\nThree\n', orderedList)
       })
 
-      it('turns selection into list if partial line is selected', function () {
+      it('turns line into list if partial line is selected', function () {
         setVisualValue('One\nT|w|o\nThree\n')
         clickToolbar(toolbarItem)
         assertNormalizedList('One\n\n- T|w|o\n\nThree\n', orderedList)
       })
 
-      it('turns selection into list if two lines are selected', function () {
+      it('turns two lines into list if two lines are selected', function () {
         setVisualValue('|One\nTwo|\nThree\n')
         clickToolbar(toolbarItem)
         assertNormalizedList('|- One\n- Two|\n\nThree\n', orderedList)
       })
 
-      it('turns selection into list if 2 lines are partially selected', function () {
+      it('turns two lines into list if 2 lines are partially selected', function () {
         setVisualValue('O|ne\nTw|o\nThree\n')
         clickToolbar(toolbarItem)
         assertNormalizedList('- O|ne\n- Tw|o\n\nThree\n', orderedList)

--- a/test/test.js
+++ b/test/test.js
@@ -619,14 +619,14 @@ describe('markdown-toolbar-element', function () {
         setVisualValue('One\n|Two\nThree|\n')
         clickToolbar('md-ordered-list')
         clickToolbar('md-unordered-list')
-        assert.equal('One\n\n|- Two\n- Three|\n', visualValue())
+        assert.equal('One\n\n- Two|\n- Three\n|', visualValue())
       })
 
       it('does not stack list styles when selecting one line', function () {
         setVisualValue('One\n|Two|\nThree|\n')
         clickToolbar('md-ordered-list')
         clickToolbar('md-unordered-list')
-        assert.equal('One\n\n|- Two\n- Three|\n', visualValue())
+        assert.equal('One\n\n- Two|\n\nT|hree', visualValue())
       })
 
       it('turns line into list when you click the unordered list icon with selection', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -512,19 +512,19 @@ describe('markdown-toolbar-element', function () {
       it('turns line into list if partial line is selected', function () {
         setVisualValue('One\nT|w|o\nThree\n')
         clickToolbar('md-ordered-list')
-        assert.equal('One\n\n1. T|w|o\n\nThree\n', visualValue())
+        assert.equal('One\n\n|1. Two|\n\nThree\n', visualValue())
       })
 
       it('turns two lines into list if two lines are selected', function () {
         setVisualValue('|One\nTwo|\nThree\n')
         clickToolbar('md-ordered-list')
-        assert.equal('1. |One\n2. Two|\n\nThree\n', visualValue())
+        assert.equal('|1. One\n2. Two|\n\nThree\n', visualValue())
       })
 
       it('turns two lines into list if 2 lines are partially selected', function () {
         setVisualValue('O|ne\nTw|o\nThree\n')
         clickToolbar('md-ordered-list')
-        assert.equal('1. O|ne\n2. Tw|o\n\nThree\n', visualValue())
+        assert.equal('|1. One\n2. Two|\n\nThree\n', visualValue())
       })
     })
 
@@ -556,19 +556,19 @@ describe('markdown-toolbar-element', function () {
       it('turns line into list if partial line is selected', function () {
         setVisualValue('One\nT|w|o\nThree\n')
         clickToolbar('md-unordered-list')
-        assert.equal('One\n\n- T|w|o\n\nThree\n', visualValue())
+        assert.equal('One\n\n|- Two|\n\nThree\n', visualValue())
       })
 
       it('turns two lines into list if two lines are selected', function () {
         setVisualValue('|One\nTwo|\nThree\n')
         clickToolbar('md-unordered-list')
-        assert.equal('- |One\n- Two|\n\nThree\n', visualValue())
+        assert.equal('|- One\n- Two|\n\nThree\n', visualValue())
       })
 
       it('turns two lines into list if 2 lines are partially selected', function () {
         setVisualValue('O|ne\nTw|o\nThree\n')
         clickToolbar('md-unordered-list')
-        assert.equal('- O|ne\n- Tw|o\n\nThree\n', visualValue())
+        assert.equal('|- One\n- Two|\n\nThree\n', visualValue())
       })
 
       it('undo list if cursor at end of line', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -32,17 +32,6 @@ describe('markdown-toolbar-element', function () {
       toolbar.querySelector(selector).click()
     }
 
-    function assertNormalizedList(str, ordered = false) {
-      let listIndex = 0
-      const stringToCompare = ordered
-        ? str.replace('- ', (matched, index, original) => {
-            ++listIndex
-            return `${listIndex}. `
-          })
-        : str
-      assert.equal(stringToCompare, visualValue())
-    }
-
     function visualValue() {
       const textarea = document.querySelector('textarea')
       const before = textarea.value.slice(0, textarea.selectionStart)
@@ -495,63 +484,49 @@ describe('markdown-toolbar-element', function () {
       })
     })
 
-    function listTests(toolbarItem, orderedList) {
+    describe('unordered list', function () {
       it('turns line into list if cursor at end of line', function () {
         setVisualValue('One\nTwo|\nThree\n')
-        clickToolbar(toolbarItem)
-        assertNormalizedList('One\n\n- Two|\n\nThree\n', orderedList)
+        clickToolbar('md-unordered-list')
+        assert.equal('One\n\n- Two|\n\nThree\n', visualValue())
       })
 
       it('turns line into list if cursor at end of document', function () {
         setVisualValue('One\nTwo\nThree|')
-        clickToolbar(toolbarItem)
-        assertNormalizedList('One\nTwo\n\n- Three|', orderedList)
+        clickToolbar('md-unordered-list')
+        assert.equal('One\nTwo\n\n- Three|', visualValue())
       })
 
       it('turns line into list if cursor at beginning of line', function () {
         setVisualValue('One\n|Two\nThree\n')
-        clickToolbar(toolbarItem)
-        assertNormalizedList('One\n\n- |Two\n\nThree\n', orderedList)
+        clickToolbar('md-unordered-list')
+        assert.equal('One\n\n- |Two\n\nThree\n', visualValue())
       })
 
       it('turns line into list if cursor at middle of line', function () {
         setVisualValue('One\nT|wo\nThree\n')
-        clickToolbar(toolbarItem)
-        assertNormalizedList('One\n\n- T|wo\n\nThree\n', orderedList)
-      })
-
-      it('turns selection into list if line is selected', function () {
-        setVisualValue('One\n|Two|\nThree\n')
-        clickToolbar(toolbarItem)
-        assertNormalizedList('One\n\n- |Two|\n\nThree\n', orderedList)
+        clickToolbar('md-unordered-list')
+        assert.equal('One\n\n- T|wo\n\nThree\n', visualValue())
       })
 
       it('turns line into list if partial line is selected', function () {
         setVisualValue('One\nT|w|o\nThree\n')
-        clickToolbar(toolbarItem)
-        assertNormalizedList('One\n\n- T|w|o\n\nThree\n', orderedList)
+        clickToolbar('md-unordered-list')
+        assert.equal('One\n\n- T|w|o\n\nThree\n', visualValue())
       })
 
       it('turns two lines into list if two lines are selected', function () {
         setVisualValue('|One\nTwo|\nThree\n')
-        clickToolbar(toolbarItem)
-        assertNormalizedList('|- One\n- Two|\n\nThree\n', orderedList)
+        clickToolbar('md-unordered-list')
+        assert.equal('|- One\n- Two|\n\nThree\n', visualValue())
       })
 
       it('turns two lines into list if 2 lines are partially selected', function () {
         setVisualValue('O|ne\nTw|o\nThree\n')
-        clickToolbar(toolbarItem)
-        assertNormalizedList('- O|ne\n- Tw|o\n\nThree\n', orderedList)
+        clickToolbar('md-unordered-list')
+        assert.equal('- O|ne\n- Tw|o\n\nThree\n', visualValue())
       })
       // TODO: Add undo test for all of this
-    }
-
-    describe('unordered list', function () {
-      listTests('md-unordered-list', false)
-    })
-
-    describe('ordered list', function () {
-      listTests('md-ordered-list', true)
     })
 
     describe('lists', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -526,6 +526,48 @@ describe('markdown-toolbar-element', function () {
         clickToolbar('md-ordered-list')
         assert.equal('|1. One\n2. Two|\n\nThree\n', visualValue())
       })
+
+      it('undo list if cursor at end of line', function () {
+        setVisualValue('One\n\n1. Two|\n\nThree\n')
+        clickToolbar('md-ordered-list')
+        assert.equal('One\n\nTwo|\n\nThree\n', visualValue())
+      })
+
+      it('undo list if cursor at end of document', function () {
+        setVisualValue('One\nTwo\n\n1. Three|')
+        clickToolbar('md-ordered-list')
+        assert.equal('One\nTwo\n\nThree|', visualValue())
+      })
+
+      it('undo list if cursor at beginning of line', function () {
+        setVisualValue('One\n\n1. |Two\n\nThree\n')
+        clickToolbar('md-ordered-list')
+        assert.equal('One\n\n|Two\n\nThree\n', visualValue())
+      })
+
+      it('undo list if cursor at middle of line', function () {
+        setVisualValue('One\n\n1. T|wo\n\nThree\n')
+        clickToolbar('md-ordered-list')
+        assert.equal('One\n\nT|wo\n\nThree\n', visualValue())
+      })
+
+      it('undo list if partial line is selected', function () {
+        setVisualValue('One\n\n1. T|w|o\n\nThree\n')
+        clickToolbar('md-ordered-list')
+        assert.equal('One\n\n|Two|\n\nThree\n', visualValue())
+      })
+
+      it('undo two lines list if two lines are selected', function () {
+        setVisualValue('|1. One\n2. Two|\n\nThree\n')
+        clickToolbar('md-ordered-list')
+        assert.equal('|One\nTwo\n\n|Three\n', visualValue())
+      })
+
+      it('undo two lines list if 2 lines are partially selected', function () {
+        setVisualValue('1. O|ne\n2. Tw|o\n\nThree\n')
+        clickToolbar('md-ordered-list')
+        assert.equal('|One\nTwo\n\n|Three\n', visualValue())
+      })
     })
 
     describe('unordered list', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -530,43 +530,43 @@ describe('markdown-toolbar-element', function () {
       it('undo list if cursor at end of line', function () {
         setVisualValue('One\n\n- Two|\n\nThree\n')
         clickToolbar('md-unordered-list')
-        assert.equal('One\nTwo|\nThree\n', visualValue())
+        assert.equal('One\n\nTwo|\n\nThree\n', visualValue())
       })
 
       it('undo list if cursor at end of document', function () {
         setVisualValue('One\nTwo\n\n- Three|')
         clickToolbar('md-unordered-list')
-        assert.equal('One\nTwo\nThree|', visualValue())
+        assert.equal('One\nTwo\n\nThree|', visualValue())
       })
 
       it('undo list if cursor at beginning of line', function () {
         setVisualValue('One\n\n- |Two\n\nThree\n')
         clickToolbar('md-unordered-list')
-        assert.equal('One\n|Two\nThree\n', visualValue())
+        assert.equal('One\n\n|Two\n\nThree\n', visualValue())
       })
 
       it('undo list if cursor at middle of line', function () {
         setVisualValue('One\n\n- T|wo\n\nThree\n')
         clickToolbar('md-unordered-list')
-        assert.equal('One\nT|wo\nThree\n', visualValue())
+        assert.equal('One\n\nT|wo\n\nThree\n', visualValue())
       })
 
       it('undo list if partial line is selected', function () {
         setVisualValue('One\n\n- T|w|o\n\nThree\n')
         clickToolbar('md-unordered-list')
-        assert.equal('One\nT|w|o\nThree\n', visualValue())
+        assert.equal('One\n\nT|w|o\n\nThree\n', visualValue())
       })
 
       it('undo two lines list if two lines are selected', function () {
         setVisualValue('|- One\n- Two|\n\nThree\n')
         clickToolbar('md-unordered-list')
-        assert.equal('|One\nTwo|\nThree\n', visualValue())
+        assert.equal('|One\nTwo|\n\nThree\n', visualValue())
       })
 
       it('undo two lines list if 2 lines are partially selected', function () {
         setVisualValue('- O|ne\n- Tw|o\n\nThree\n')
         clickToolbar('md-unordered-list')
-        assert.equal('O|ne\nTw|o\nThree\n', visualValue())
+        assert.equal('O|ne\nTw|o\n\nThree\n', visualValue())
       })
     })
 

--- a/test/test.js
+++ b/test/test.js
@@ -32,6 +32,17 @@ describe('markdown-toolbar-element', function () {
       toolbar.querySelector(selector).click()
     }
 
+    function assertNormalizedList(str, ordered = false) {
+      let listIndex = 0
+      const stringToCompare = ordered
+        ? str.replace('- ', (matched, index, original) => {
+            ++listIndex
+            return `${listIndex}. `
+          })
+        : str
+      assert.equal(stringToCompare, visualValue())
+    }
+
     function visualValue() {
       const textarea = document.querySelector('textarea')
       const before = textarea.value.slice(0, textarea.selectionStart)
@@ -484,49 +495,63 @@ describe('markdown-toolbar-element', function () {
       })
     })
 
-    describe('unordered list', function () {
+    function listTests(toolbarItem, orderedList) {
       it('turns line into list if cursor at end of line', function () {
         setVisualValue('One\nTwo|\nThree\n')
-        clickToolbar('md-unordered-list')
-        assert.equal('One\n\n- Two|\n\nThree\n', visualValue())
+        clickToolbar(toolbarItem)
+        assertNormalizedList('One\n\n- Two|\n\nThree\n', orderedList)
       })
 
       it('turns line into list if cursor at end of document', function () {
         setVisualValue('One\nTwo\nThree|')
-        clickToolbar('md-unordered-list')
-        assert.equal('One\nTwo\n\n- Three|', visualValue())
+        clickToolbar(toolbarItem)
+        assertNormalizedList('One\nTwo\n\n- Three|', orderedList)
       })
 
       it('turns line into list if cursor at beginning of line', function () {
         setVisualValue('One\n|Two\nThree\n')
-        clickToolbar('md-unordered-list')
-        assert.equal('One\n\n- |Two\n\nThree\n', visualValue())
+        clickToolbar(toolbarItem)
+        assertNormalizedList('One\n\n- |Two\n\nThree\n', orderedList)
       })
 
       it('turns line into list if cursor at middle of line', function () {
         setVisualValue('One\nT|wo\nThree\n')
-        clickToolbar('md-unordered-list')
-        assert.equal('One\n\n- T|wo\n\nThree\n', visualValue())
+        clickToolbar(toolbarItem)
+        assertNormalizedList('One\n\n- T|wo\n\nThree\n', orderedList)
+      })
+
+      it('turns selection into list if line is selected', function () {
+        setVisualValue('One\n|Two|\nThree\n')
+        clickToolbar(toolbarItem)
+        assertNormalizedList('One\n\n- |Two|\n\nThree\n', orderedList)
       })
 
       it('turns selection into list if partial line is selected', function () {
         setVisualValue('One\nT|w|o\nThree\n')
-        clickToolbar('md-unordered-list')
-        assert.equal('One\n\n- T|w|o\n\nThree\n', visualValue())
+        clickToolbar(toolbarItem)
+        assertNormalizedList('One\n\n- T|w|o\n\nThree\n', orderedList)
       })
 
       it('turns selection into list if two lines are selected', function () {
         setVisualValue('|One\nTwo|\nThree\n')
-        clickToolbar('md-unordered-list')
-        assert.equal('|- One\n- Two|\n\nThree\n', visualValue())
+        clickToolbar(toolbarItem)
+        assertNormalizedList('|- One\n- Two|\n\nThree\n', orderedList)
       })
 
       it('turns selection into list if 2 lines are partially selected', function () {
         setVisualValue('O|ne\nTw|o\nThree\n')
-        clickToolbar('md-unordered-list')
-        assert.equal('- O|ne\n- Tw|o\n\nThree\n', visualValue())
+        clickToolbar(toolbarItem)
+        assertNormalizedList('- O|ne\n- Tw|o\n\nThree\n', orderedList)
       })
       // TODO: Add undo test for all of this
+    }
+
+    describe('unordered list', function () {
+      listTests('md-unordered-list', false)
+    })
+
+    describe('ordered list', function () {
+      listTests('md-ordered-list', true)
     })
 
     describe('lists', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -484,6 +484,50 @@ describe('markdown-toolbar-element', function () {
       })
     })
 
+    describe('ordered list', function () {
+      it('turns line into list if cursor at end of line', function () {
+        setVisualValue('One\nTwo|\nThree\n')
+        clickToolbar('md-ordered-list')
+        assert.equal('One\n\n1. Two|\n\nThree\n', visualValue())
+      })
+
+      it('turns line into list if cursor at end of document', function () {
+        setVisualValue('One\nTwo\nThree|')
+        clickToolbar('md-ordered-list')
+        assert.equal('One\nTwo\n\n1. Three|', visualValue())
+      })
+
+      it('turns line into list if cursor at beginning of line', function () {
+        setVisualValue('One\n|Two\nThree\n')
+        clickToolbar('md-ordered-list')
+        assert.equal('One\n\n1. |Two\n\nThree\n', visualValue())
+      })
+
+      it('turns line into list if cursor at middle of line', function () {
+        setVisualValue('One\nT|wo\nThree\n')
+        clickToolbar('md-ordered-list')
+        assert.equal('One\n\n1. T|wo\n\nThree\n', visualValue())
+      })
+
+      it('turns line into list if partial line is selected', function () {
+        setVisualValue('One\nT|w|o\nThree\n')
+        clickToolbar('md-ordered-list')
+        assert.equal('One\n\n1. T|w|o\n\nThree\n', visualValue())
+      })
+
+      it('turns two lines into list if two lines are selected', function () {
+        setVisualValue('|One\nTwo|\nThree\n')
+        clickToolbar('md-ordered-list')
+        assert.equal('1. |One\n2. Two|\n\nThree\n', visualValue())
+      })
+
+      it('turns two lines into list if 2 lines are partially selected', function () {
+        setVisualValue('O|ne\nTw|o\nThree\n')
+        clickToolbar('md-ordered-list')
+        assert.equal('1. O|ne\n2. Tw|o\n\nThree\n', visualValue())
+      })
+    })
+
     describe('unordered list', function () {
       it('turns line into list if cursor at end of line', function () {
         setVisualValue('One\nTwo|\nThree\n')

--- a/test/test.js
+++ b/test/test.js
@@ -484,6 +484,51 @@ describe('markdown-toolbar-element', function () {
       })
     })
 
+    describe('unordered list', function () {
+      it('turns line into list if cursor at end of line', function () {
+        setVisualValue('One\nTwo|\nThree\n')
+        clickToolbar('md-unordered-list')
+        assert.equal('One\n\n- Two|\n\nThree\n', visualValue())
+      })
+
+      it('turns line into list if cursor at end of document', function () {
+        setVisualValue('One\nTwo\nThree|')
+        clickToolbar('md-unordered-list')
+        assert.equal('One\nTwo\n\n- Three|', visualValue())
+      })
+
+      it('turns line into list if cursor at beginning of line', function () {
+        setVisualValue('One\n|Two\nThree\n')
+        clickToolbar('md-unordered-list')
+        assert.equal('One\n\n- |Two\n\nThree\n', visualValue())
+      })
+
+      it('turns line into list if cursor at middle of line', function () {
+        setVisualValue('One\nT|wo\nThree\n')
+        clickToolbar('md-unordered-list')
+        assert.equal('One\n\n- T|wo\n\nThree\n', visualValue())
+      })
+
+      it('turns selection into list if partial line is selected', function () {
+        setVisualValue('One\nT|w|o\nThree\n')
+        clickToolbar('md-unordered-list')
+        assert.equal('One\n\n- T|w|o\n\nThree\n', visualValue())
+      })
+
+      it('turns selection into list if two lines are selected', function () {
+        setVisualValue('|One\nTwo|\nThree\n')
+        clickToolbar('md-unordered-list')
+        assert.equal('|- One\n- Two|\n\nThree\n', visualValue())
+      })
+
+      it('turns selection into list if 2 lines are partially selected', function () {
+        setVisualValue('O|ne\nTw|o\nThree\n')
+        clickToolbar('md-unordered-list')
+        assert.equal('- O|ne\n- Tw|o\n\nThree\n', visualValue())
+      })
+      // TODO: Add undo test for all of this
+    })
+
     describe('lists', function () {
       it('turns line into list when you click the unordered list icon with selection', function () {
         setVisualValue('One\n|Two|\nThree\n')

--- a/test/test.js
+++ b/test/test.js
@@ -619,20 +619,20 @@ describe('markdown-toolbar-element', function () {
         setVisualValue('One\n|Two\nThree|\n')
         clickToolbar('md-ordered-list')
         clickToolbar('md-unordered-list')
-        assert.equal('One\n\n- Two|\n- Three\n|', visualValue())
+        assert.equal('One\n\n|- Two\n- Three\n|', visualValue())
       })
 
       it('does not stack list styles when selecting one line', function () {
-        setVisualValue('One\n|Two|\nThree|\n')
+        setVisualValue('One\n|Two|\nThree\n')
         clickToolbar('md-ordered-list')
         clickToolbar('md-unordered-list')
-        assert.equal('One\n\n- Two|\n\nT|hree', visualValue())
+        assert.equal('One\n\n|- Two|\n\nThree', visualValue())
       })
 
       it('turns line into list when you click the unordered list icon with selection', function () {
         setVisualValue('One\n|Two|\nThree\n')
         clickToolbar('md-unordered-list')
-        assert.equal('One\n\n- |Two|\n\nThree\n', visualValue())
+        assert.equal('One\n\n|- Two|\n\nThree\n', visualValue())
       })
 
       it('turns line into list when you click the unordered list icon without selection', function () {
@@ -648,21 +648,21 @@ describe('markdown-toolbar-element', function () {
       })
 
       it('prefixes newlines when a list is created on the last line', function () {
-        setVisualValue("Here's a list:|One|")
+        setVisualValue("Here's a |list:|")
         clickToolbar('md-unordered-list')
-        assert.equal("Here's a list:\n\n- |One|", visualValue())
+        assert.equal("|- Here's a list:|", visualValue())
       })
 
       it('surrounds list with newlines when a list is created on an existing line', function () {
         setVisualValue("Here's a list:|One|\nThis is text after the list")
         clickToolbar('md-unordered-list')
-        assert.equal("Here's a list:\n\n- |One|\n\nThis is text after the list", visualValue())
+        assert.equal("|- Here's a list:One|\n\nThis is text after the list", visualValue())
       })
 
       it('undo the list when button is clicked again', function () {
         setVisualValue('|Two|')
         clickToolbar('md-unordered-list')
-        assert.equal('- |Two|', visualValue())
+        assert.equal('|- Two|', visualValue())
         clickToolbar('md-unordered-list')
         assert.equal('|Two|', visualValue())
       })
@@ -670,7 +670,7 @@ describe('markdown-toolbar-element', function () {
       it('creates ordered list without selection', function () {
         setVisualValue('apple\n|pear\nbanana\n')
         clickToolbar('md-ordered-list')
-        assert.equal('apple\n\n1. |\n\npear\nbanana\n', visualValue())
+        assert.equal('apple\n\n1. |pear\n\nbanana\n', visualValue())
       })
 
       it('undo an ordered list without selection', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -560,13 +560,13 @@ describe('markdown-toolbar-element', function () {
       it('undo two lines list if two lines are selected', function () {
         setVisualValue('|1. One\n2. Two|\n\nThree\n')
         clickToolbar('md-ordered-list')
-        assert.equal('|One\nTwo\n\n|Three\n', visualValue())
+        assert.equal('|One\nTwo|\n\nThree\n', visualValue())
       })
 
       it('undo two lines list if 2 lines are partially selected', function () {
         setVisualValue('1. O|ne\n2. Tw|o\n\nThree\n')
         clickToolbar('md-ordered-list')
-        assert.equal('|One\nTwo\n\n|Three\n', visualValue())
+        assert.equal('|One\nTwo|\n\nThree\n', visualValue())
       })
     })
 
@@ -646,13 +646,13 @@ describe('markdown-toolbar-element', function () {
       it('undo two lines list if two lines are selected', function () {
         setVisualValue('|- One\n- Two|\n\nThree\n')
         clickToolbar('md-unordered-list')
-        assert.equal('|One\nTwo\n\n|Three\n', visualValue())
+        assert.equal('|One\nTwo|\n\nThree\n', visualValue())
       })
 
       it('undo two lines list if 2 lines are partially selected', function () {
         setVisualValue('- O|ne\n- Tw|o\n\nThree\n')
         clickToolbar('md-unordered-list')
-        assert.equal('|One\nTwo\n\n|Three\n', visualValue())
+        assert.equal('|One\nTwo|\n\nThree\n', visualValue())
       })
     })
 
@@ -748,7 +748,7 @@ describe('markdown-toolbar-element', function () {
       it('undo an ordered list by selecting multiple styled lines', function () {
         setVisualValue('|1. One\n2. Two\n3. Three|\n')
         clickToolbar('md-ordered-list')
-        assert.equal('|One\nTwo\nThree\n|', visualValue())
+        assert.equal('|One\nTwo\nThree|\n', visualValue())
       })
     })
 

--- a/test/test.js
+++ b/test/test.js
@@ -518,7 +518,7 @@ describe('markdown-toolbar-element', function () {
       it('turns two lines into list if two lines are selected', function () {
         setVisualValue('|One\nTwo|\nThree\n')
         clickToolbar('md-unordered-list')
-        assert.equal('|- One\n- Two|\n\nThree\n', visualValue())
+        assert.equal('- |One\n- Two|\n\nThree\n', visualValue())
       })
 
       it('turns two lines into list if 2 lines are partially selected', function () {


### PR DESCRIPTION
This PR attempts to make list behaviors more consistent and also fixes list stacking.

### List stacking

| Before | After |
|--------|--------|
| ![stacking-before](https://user-images.githubusercontent.com/121539/144333125-504fa97f-c45a-43f3-90c7-a44b617ceb83.gif) | ![stacking-after](https://user-images.githubusercontent.com/121539/144333134-47296684-19b2-4f32-9a4b-4365814417f6.gif) |

### List behavior

This PR aims to make the behavior of ordered and unordered lists more consistent.
We now always consider the whole line instead of relying on selection or caret position.
If no text is selected, the current caret position is retained (that is also true for when undoing a list).
If text is selected, the whole line that was considered for the operation will be selected after the operation is complete.

This resolves an inconsistency between ordered and unordered lists, where creating a ordered list would split a line at the caret position, while an unordered list would not:

| List Type | Before | After |
|--------|--------|--------|
| ordered list | ![ordered-before](https://user-images.githubusercontent.com/121539/144333931-cd49cdf9-0000-4532-9eb4-d3570d099127.gif) | ![ordered-after](https://user-images.githubusercontent.com/121539/144333929-187624bd-cac2-442c-99e2-56de372665b6.gif) |
| unordered list | ![unordered-before](https://user-images.githubusercontent.com/121539/144333965-92f4e1c9-ac1a-41bb-8b70-0cafa617ccaf.gif) | ![unordered-after](https://user-images.githubusercontent.com/121539/144333958-6f6dd8bb-cc70-4c45-8303-9a445635cd4a.gif) | 

I tried to add as much test coverage as I could think of and adjusted the existing tests to the new behavior.

This fixes https://github.com/github/special-projects/issues/598 and supersedes https://github.com/github/markdown-toolbar-element/pull/52
