### PR TITLE
Use the connectedCallback function to set button styles instead of the constructor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,20 @@ class MarkdownButtonElement extends HTMLElement {
 class MarkdownHeaderButtonElement extends MarkdownButtonElement {
   connectedCallback() {
     const level = parseInt(this.getAttribute('level') || '3', 10)
+    this.#setLevelStyle(level)
+  }
+
+  static get observedAttributes() {
+    return ['level']
+  }
+
+  attributeChangedCallback(name: string, oldValue: string, newValue: string) {
+    if (name !== 'level') return
+    const level = parseInt(newValue || '3', 10)
+    this.#setLevelStyle(level)
+  }
+
+  #setLevelStyle(level: number) {
     if (level < 1 || level > 6) {
       return
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,9 +111,7 @@ class MarkdownButtonElement extends HTMLElement {
 }
 
 class MarkdownHeaderButtonElement extends MarkdownButtonElement {
-  constructor() {
-    super()
-
+  connectedCallback() {
     const level = parseInt(this.getAttribute('level') || '3', 10)
     if (level < 1 || level > 6) {
       return

--- a/src/index.ts
+++ b/src/index.ts
@@ -274,10 +274,6 @@ if (!window.customElements.get('md-strikethrough')) {
 }
 
 class MarkdownToolbarElement extends HTMLElement {
-  constructor() {
-    super()
-  }
-
   connectedCallback(): void {
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'toolbar')

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,8 +130,7 @@ if (!window.customElements.get('md-header')) {
 }
 
 class MarkdownBoldButtonElement extends MarkdownButtonElement {
-  constructor() {
-    super()
+  connectedCallback() {
     styles.set(this, {prefix: '**', suffix: '**', trimFirst: true})
   }
 }
@@ -142,8 +141,7 @@ if (!window.customElements.get('md-bold')) {
 }
 
 class MarkdownItalicButtonElement extends MarkdownButtonElement {
-  constructor() {
-    super()
+  connectedCallback() {
     styles.set(this, {prefix: '_', suffix: '_', trimFirst: true})
   }
 }
@@ -154,8 +152,7 @@ if (!window.customElements.get('md-italic')) {
 }
 
 class MarkdownQuoteButtonElement extends MarkdownButtonElement {
-  constructor() {
-    super()
+  connectedCallback() {
     styles.set(this, {prefix: '> ', multiline: true, surroundWithNewlines: true})
   }
 }
@@ -166,8 +163,7 @@ if (!window.customElements.get('md-quote')) {
 }
 
 class MarkdownCodeButtonElement extends MarkdownButtonElement {
-  constructor() {
-    super()
+  connectedCallback() {
     styles.set(this, {prefix: '`', suffix: '`', blockPrefix: '```', blockSuffix: '```'})
   }
 }
@@ -178,8 +174,7 @@ if (!window.customElements.get('md-code')) {
 }
 
 class MarkdownLinkButtonElement extends MarkdownButtonElement {
-  constructor() {
-    super()
+  connectedCallback() {
     styles.set(this, {prefix: '[', suffix: '](url)', replaceNext: 'url', scanFor: 'https?://'})
   }
 }
@@ -190,8 +185,7 @@ if (!window.customElements.get('md-link')) {
 }
 
 class MarkdownImageButtonElement extends MarkdownButtonElement {
-  constructor() {
-    super()
+  connectedCallback() {
     styles.set(this, {prefix: '![', suffix: '](url)', replaceNext: 'url', scanFor: 'https?://'})
   }
 }
@@ -202,8 +196,7 @@ if (!window.customElements.get('md-image')) {
 }
 
 class MarkdownUnorderedListButtonElement extends MarkdownButtonElement {
-  constructor() {
-    super()
+  connectedCallback() {
     styles.set(this, {prefix: '- ', multiline: true, unorderedList: true})
   }
 }
@@ -214,8 +207,7 @@ if (!window.customElements.get('md-unordered-list')) {
 }
 
 class MarkdownOrderedListButtonElement extends MarkdownButtonElement {
-  constructor() {
-    super()
+  connectedCallback() {
     styles.set(this, {prefix: '1. ', multiline: true, orderedList: true})
   }
 }
@@ -226,8 +218,7 @@ if (!window.customElements.get('md-ordered-list')) {
 }
 
 class MarkdownTaskListButtonElement extends MarkdownButtonElement {
-  constructor() {
-    super()
+  connectedCallback() {
     styles.set(this, {prefix: '- [ ] ', multiline: true, surroundWithNewlines: true})
   }
 }
@@ -238,8 +229,7 @@ if (!window.customElements.get('md-task-list')) {
 }
 
 class MarkdownMentionButtonElement extends MarkdownButtonElement {
-  constructor() {
-    super()
+  connectedCallback() {
     styles.set(this, {prefix: '@', prefixSpace: true})
   }
 }
@@ -250,8 +240,7 @@ if (!window.customElements.get('md-mention')) {
 }
 
 class MarkdownRefButtonElement extends MarkdownButtonElement {
-  constructor() {
-    super()
+  connectedCallback() {
     styles.set(this, {prefix: '#', prefixSpace: true})
   }
 }
@@ -262,8 +251,7 @@ if (!window.customElements.get('md-ref')) {
 }
 
 class MarkdownStrikethroughButtonElement extends MarkdownButtonElement {
-  constructor() {
-    super()
+  connectedCallback() {
     styles.set(this, {prefix: '~~', suffix: '~~', trimFirst: true})
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -860,6 +860,15 @@ describe('markdown-toolbar-element', function () {
         clickToolbar('md-header[level="10"]')
         assert.equal('|title|', visualValue())
       })
+
+      it('dynamically changes header level based on the level attribute', function () {
+        setVisualValue('|title|')
+        const headerButton = document.querySelector('md-header[level="1"]')
+        headerButton.setAttribute('level', '2')
+        headerButton.click()
+
+        assert.equal('## |title|', visualValue())
+      })
     })
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -831,6 +831,18 @@ describe('markdown-toolbar-element', function () {
     })
 
     describe('header', function () {
+      it('sets the level correctly even when dynamically created', function () {
+        const headerElement = document.createElement('md-header')
+        headerElement.setAttribute('level', '2')
+        headerElement.textContent = 'h2'
+        const toolbar = document.querySelector('markdown-toolbar')
+        toolbar.appendChild(headerElement)
+
+        setVisualValue('|title|')
+        clickToolbar('md-header[level="2"]')
+        assert.equal('## |title|', visualValue())
+      })
+
       it('inserts header syntax with cursor in description', function () {
         setVisualValue('|title|')
         clickToolbar('md-header')


### PR DESCRIPTION
Building a header button in memory with a custom heading ("level") causes a unexpected behaviour. Consider the following example:

```js
const headerButton = document.createElement('md-header') // The constructor is executed at this point.
headerButton.setAttribute('level', '1')                  // Has no effect since the style has already been set.
headerButton.textContent = 'h1'
document.body.appendChild(headerButton)
```

While we expect to have a header button that outputs a single hash (`#`), we have a button that outputs three (`###`). The constructor sets the styles based on the `level` attribute when the component is initialised. Changing the constructor to a `connectedCallback` function ensures that the button styles aren't set until the button is connected to the DOM.

Since `constructor` can be error-prone for custom elements and keep all the components similar, I've also changed all the constructors to `connectedCallback` functions.

Finally, even though we don't expect header buttons to change levels dynamically during an application lifetime, we should ensure that it works as expected. So I've added an `attributeChangedCallback` to the header button element. The callback changes the level style based on the `level` attribute.

Fixes #40 and possibly #45