### PR TITLE
allow use of <button> elements with `data-md-button="{style}"

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -869,6 +869,17 @@ describe('markdown-toolbar-element', function () {
 
         assert.equal('## |title|', visualValue())
       })
+
+      it('can be triggered from a data-md-button', function () {
+        const headerElement = document.createElement('button')
+        headerElement.setAttribute('data-md-button', 'header-6')
+        const toolbar = document.querySelector('markdown-toolbar')
+        toolbar.appendChild(headerElement)
+        setVisualValue('|title|')
+        headerElement.click()
+
+        assert.equal('###### |title|', visualValue())
+      })
     })
   })
 })


### PR DESCRIPTION
This allows the use of `data-md-button={style}`, where `style` is a specific style like `code`, `header-6`, etc.

The _intent_ of this is to allow arbitrary tags like `<div>` or `<button>` to be used over the `<md-button>` variants.


/cc @jonrohan 