### PR TITLE
Don't set a tabindex=0 when the toolbar has data-no-focus attribute applied

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -324,9 +324,11 @@ class MarkdownToolbarElement extends HTMLElement {
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'toolbar')
     }
-    this.addEventListener('keydown', focusKeydown)
-    this.setAttribute('tabindex', '0')
-    this.addEventListener('focus', onToolbarFocus, {once: true})
+    if (!this.hasAttribute('data-no-focus')) {
+      this.addEventListener('keydown', focusKeydown)
+      this.setAttribute('tabindex', '0')
+      this.addEventListener('focus', onToolbarFocus, {once: true})
+    }
     this.addEventListener('keydown', keydown(applyFromToolbar))
     this.addEventListener('click', applyFromToolbar)
   }
@@ -349,7 +351,6 @@ class MarkdownToolbarElement extends HTMLElement {
 
 function onToolbarFocus({target}: FocusEvent) {
   if (!(target instanceof Element)) return
-  if (target.hasAttribute('data-no-focus')) return
   target.removeAttribute('tabindex')
   let tabindex = '0'
   for (const button of getButtons(target)) {
@@ -366,7 +367,6 @@ function focusKeydown(event: KeyboardEvent) {
   if (key !== 'ArrowRight' && key !== 'ArrowLeft' && key !== 'Home' && key !== 'End') return
   const toolbar = event.currentTarget
   if (!(toolbar instanceof HTMLElement)) return
-  if (toolbar.hasAttribute('data-no-focus')) return
   const buttons = getButtons(toolbar)
   const index = buttons.indexOf(event.target as HTMLElement)
   const length = buttons.length

--- a/src/index.ts
+++ b/src/index.ts
@@ -319,22 +319,43 @@ function applyFromToolbar(event: Event) {
   applyStyle(target, style)
 }
 
+function setFocusManagement(toolbar: MarkdownToolbarElement) {
+  toolbar.addEventListener('keydown', focusKeydown)
+  toolbar.setAttribute('tabindex', '0')
+  toolbar.addEventListener('focus', onToolbarFocus, {once: true})
+}
+
+function unsetFocusManagement(toolbar: MarkdownToolbarElement) {
+  toolbar.removeEventListener('keydown', focusKeydown)
+  toolbar.removeAttribute('tabindex')
+  toolbar.removeEventListener('focus', onToolbarFocus)
+}
+
 class MarkdownToolbarElement extends HTMLElement {
+  static observedAttributes = ['data-no-focus']
+
   connectedCallback(): void {
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'toolbar')
     }
     if (!this.hasAttribute('data-no-focus')) {
-      this.addEventListener('keydown', focusKeydown)
-      this.setAttribute('tabindex', '0')
-      this.addEventListener('focus', onToolbarFocus, {once: true})
+      setFocusManagement(this)
     }
     this.addEventListener('keydown', keydown(applyFromToolbar))
     this.addEventListener('click', applyFromToolbar)
   }
 
+  attributeChangedCallback(name: string, oldValue: string, newValue: string): void {
+    if (name !== 'data-no-focus') return
+    if (newValue === null) {
+      setFocusManagement(this)
+    } else {
+      unsetFocusManagement(this)
+    }
+  }
+
   disconnectedCallback(): void {
-    this.removeEventListener('keydown', focusKeydown)
+    unsetFocusManagement(this)
   }
 
   get field(): HTMLTextAreaElement | null {

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,5 @@
+chai.config.truncateThreshold = Infinity
+
 describe('markdown-toolbar-element', function () {
   describe('element creation', function () {
     it('creates from document.createElement', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -96,6 +96,7 @@ describe('markdown-toolbar-element', function () {
 
     describe('focus management', function () {
       function focusFirstButton() {
+        document.querySelector('markdown-toolbar').focus()
         const button = document.querySelector('md-bold')
         button.focus()
       }
@@ -110,10 +111,6 @@ describe('markdown-toolbar-element', function () {
       function getElementsWithTabindex(index) {
         return [...document.querySelectorAll(`markdown-toolbar [tabindex="${index}"]`)]
       }
-
-      beforeEach(() => {
-        document.querySelector('markdown-toolbar').focus()
-      })
 
       it('moves focus to next button when ArrowRight is pressed', function () {
         focusFirstButton()

--- a/test/test.js
+++ b/test/test.js
@@ -135,8 +135,7 @@ describe('markdown-toolbar-element', function () {
         document.querySelector('markdown-toolbar').setAttribute('data-no-focus', '')
         focusFirstButton()
         pushKeyOnFocussedButton('ArrowRight')
-        assert.deepEqual(getElementsWithTabindex(0), [document.querySelector('md-bold')])
-        assert.deepEqual(getElementsWithTabindex(0), [document.activeElement])
+        assert.lengthOf(getElementsWithTabindex(0), 0)
       })
 
       it('cycles focus round to last element from first when ArrowLeft is pressed', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,3 @@
-chai.config.truncateThreshold = Infinity
-
 describe('markdown-toolbar-element', function () {
   describe('element creation', function () {
     it('creates from document.createElement', function () {


### PR DESCRIPTION
The `markdown-toolbar` element is grabbing focus when using `data-no-focus`. I think this is because of the tabindex that's being applied.

<img width="902" alt="image" src="https://github.com/github/markdown-toolbar-element/assets/54012/8ec9f7e2-f322-4cc5-a60c-83b49c3b7a36">

To fix this, I'm moving the `this.hasAttribute('data-no-focus')` into the connectedCallback constructor and also avoiding adding eventListeners when this occurs