### PR TITLE
fix: call super.connectedCallback() in button sub-components

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -145,6 +145,7 @@ class MarkdownButtonElement extends HTMLElement {
 
 class MarkdownHeaderButtonElement extends MarkdownButtonElement {
   connectedCallback() {
+    super.connectedCallback()
     const level = parseInt(this.getAttribute('level') || '3', 10)
     this.#setLevelStyle(level)
   }
@@ -178,6 +179,7 @@ if (!window.customElements.get('md-header')) {
 
 class MarkdownBoldButtonElement extends MarkdownButtonElement {
   connectedCallback() {
+    super.connectedCallback()
     styles.set(this, {prefix: '**', suffix: '**', trimFirst: true})
   }
 }
@@ -189,6 +191,7 @@ if (!window.customElements.get('md-bold')) {
 
 class MarkdownItalicButtonElement extends MarkdownButtonElement {
   connectedCallback() {
+    super.connectedCallback()
     styles.set(this, {prefix: '_', suffix: '_', trimFirst: true})
   }
 }
@@ -200,6 +203,7 @@ if (!window.customElements.get('md-italic')) {
 
 class MarkdownQuoteButtonElement extends MarkdownButtonElement {
   connectedCallback() {
+    super.connectedCallback()
     styles.set(this, {prefix: '> ', multiline: true, surroundWithNewlines: true})
   }
 }
@@ -211,6 +215,7 @@ if (!window.customElements.get('md-quote')) {
 
 class MarkdownCodeButtonElement extends MarkdownButtonElement {
   connectedCallback() {
+    super.connectedCallback()
     styles.set(this, {prefix: '`', suffix: '`', blockPrefix: '```', blockSuffix: '```'})
   }
 }
@@ -222,6 +227,7 @@ if (!window.customElements.get('md-code')) {
 
 class MarkdownLinkButtonElement extends MarkdownButtonElement {
   connectedCallback() {
+    super.connectedCallback()
     styles.set(this, {prefix: '[', suffix: '](url)', replaceNext: 'url', scanFor: 'https?://'})
   }
 }
@@ -233,6 +239,7 @@ if (!window.customElements.get('md-link')) {
 
 class MarkdownImageButtonElement extends MarkdownButtonElement {
   connectedCallback() {
+    super.connectedCallback()
     styles.set(this, {prefix: '![', suffix: '](url)', replaceNext: 'url', scanFor: 'https?://'})
   }
 }
@@ -244,6 +251,7 @@ if (!window.customElements.get('md-image')) {
 
 class MarkdownUnorderedListButtonElement extends MarkdownButtonElement {
   connectedCallback() {
+    super.connectedCallback()
     styles.set(this, {prefix: '- ', multiline: true, unorderedList: true})
   }
 }
@@ -255,6 +263,7 @@ if (!window.customElements.get('md-unordered-list')) {
 
 class MarkdownOrderedListButtonElement extends MarkdownButtonElement {
   connectedCallback() {
+    super.connectedCallback()
     styles.set(this, {prefix: '1. ', multiline: true, orderedList: true})
   }
 }
@@ -266,6 +275,7 @@ if (!window.customElements.get('md-ordered-list')) {
 
 class MarkdownTaskListButtonElement extends MarkdownButtonElement {
   connectedCallback() {
+    super.connectedCallback()
     styles.set(this, {prefix: '- [ ] ', multiline: true, surroundWithNewlines: true})
   }
 }
@@ -277,6 +287,7 @@ if (!window.customElements.get('md-task-list')) {
 
 class MarkdownMentionButtonElement extends MarkdownButtonElement {
   connectedCallback() {
+    super.connectedCallback()
     styles.set(this, {prefix: '@', prefixSpace: true})
   }
 }
@@ -288,6 +299,7 @@ if (!window.customElements.get('md-mention')) {
 
 class MarkdownRefButtonElement extends MarkdownButtonElement {
   connectedCallback() {
+    super.connectedCallback()
     styles.set(this, {prefix: '#', prefixSpace: true})
   }
 }
@@ -299,6 +311,7 @@ if (!window.customElements.get('md-ref')) {
 
 class MarkdownStrikethroughButtonElement extends MarkdownButtonElement {
   connectedCallback() {
+    super.connectedCallback()
     styles.set(this, {prefix: '~~', suffix: '~~', trimFirst: true})
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,43 @@ describe('markdown-toolbar-element', function () {
     })
   })
 
+  describe('role attribute', function () {
+    afterEach(function () {
+      document.body.innerHTML = ''
+    })
+
+    const buttonTags = [
+      'md-header',
+      'md-bold',
+      'md-italic',
+      'md-quote',
+      'md-code',
+      'md-link',
+      'md-image',
+      'md-unordered-list',
+      'md-ordered-list',
+      'md-task-list',
+      'md-mention',
+      'md-ref',
+      'md-strikethrough'
+    ]
+
+    for (const tag of buttonTags) {
+      it(`sets role="button" on <${tag}> when connected`, function () {
+        const el = document.createElement(tag)
+        document.body.append(el)
+        assert.equal(el.getAttribute('role'), 'button')
+      })
+
+      it(`preserves custom role on <${tag}> if already present`, function () {
+        const el = document.createElement(tag)
+        el.setAttribute('role', 'none')
+        document.body.append(el)
+        assert.equal(el.getAttribute('role'), 'none')
+      })
+    }
+  })
+
   describe('in shadow DOM', function () {
     it('finds field and inserts markdown', function () {
       const div = document.createElement('div')


### PR DESCRIPTION
### Summary

Fixes #70.

Subclasses of `MarkdownButtonElement` (`md-header`, `md-bold`, `md-italic`, `md-quote`, `md-code`, etc.) defined their own `connectedCallback()` without invoking `super.connectedCallback()`. As a result, the base class's logic to assign `role="button"` when no role is present was bypassed.

### Changes

- Call `super.connectedCallback()` in all `MarkdownButtonElement` subclasses in `src/index.ts`.
- Add test coverage in `test/test.js` confirming that each markdown button custom element sets `role="button"` on connection if missing, and preserves any existing custom role.

### Verification

- Reproduced test failure before fix (13 test failures across all button elements).
- Ran full Karma test suite: 143 passed, 0 failed.
- Ran ESLint: 0 errors, 0 warnings.
